### PR TITLE
fix CVE-2017-2809 - code injection interpreted by yaml loader

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
 import yaml
 
 with open("config.yaml", "r") as f:
-    settings = yaml.load(f)
+    settings = yaml.safe_load(f)


### PR DESCRIPTION
Hi!

A little fix for the [CVE-2017-2809](https://nvd.nist.gov/vuln/detail/CVE-2017-2809).

`yaml.load` is not safe, you can pass executable code to it!

This CVE speak about ansible-vault but the problem is the same with your application.

Example:
```shell
$ echo '!!python/object/apply:os.system ["echo powned; uname -a"]' > config.yaml
$ ./gateway.py
powned
Linux vm 4.8.0-54-generic #57~16.04.1-Ubuntu SMP Wed May 24 16:22:28 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
...
```

Have a nice day :)