### PR TITLE
Fix global mqtt_prefix try 2

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -5,7 +5,9 @@ class MqttClient:
 
   def __init__(self, config):
     self._config = config
-    self._mqttc = mqtt.Client(client_id=self.client_id, clean_session=False)
+    self._mqttc = mqtt.Client(client_id=self.client_id,
+                              clean_session=False,
+                              userdata = {'global_topic_prefix': self.topic_prefix})
 
     if self.username and self.password:
       self.mqttc.username_pw_set(self.username, self.password)

--- a/mqtt.py
+++ b/mqtt.py
@@ -59,6 +59,8 @@ class MqttClient:
     self.mqttc.connect(self.hostname, port=self.port)
 
     for topic, callback in callbacks:
+      if self.topic_prefix is not None:
+        topic = "{}/{}".format(self.topic_prefix, topic)
       self.mqttc.message_callback_add(topic, callback)
       self.mqttc.subscribe(topic)
 

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -71,7 +71,9 @@ class ThermostatWorker(BaseWorker):
     return ret
 
   def on_command(self, topic, value):
-    _, device_name, method, _ = topic.split('/')
+    if self.topic_prefix is not None:
+      _, device_name, method, _ = topic[len(self.topic_prefix+"/"):].split('/')
+
     thermostat = self.devices[device_name]
 
     value = value.decode('utf-8')

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -102,6 +102,8 @@ class WorkersManager:
     for package in package_names:
       pip_main(['install', '-q', package])
 
-  def _on_command_wrapper(self, worker_obj, client, _, c):
+  def _on_command_wrapper(self, worker_obj, client, userdata, c):
     _LOGGER.debug("on command wrapper for with %s: %s", c.topic, c.payload)
-    self._queue_command(self.Command(worker_obj.on_command, [c.topic, c.payload]))
+    global_topic_prefix = userdata['global_topic_prefix']
+    topic = c.topic[len(global_topic_prefix+'/'):] if global_topic_prefix is not None else c.topic
+    self._queue_command(self.Command(worker_obj.on_command, [topic, c.payload]))


### PR DESCRIPTION
I refer to the "topic_prefix" in the mqtt section as "global_topic_prefix" to not get confused with the "topic_prefix" in the worker section. 

After the revert of parts of the previous fix it remains that the subscription is corrected ("global_topic_prefix/topic_prefix/other/stuff/here"). But having a "global_topic_prefix" and a "topic_prefix" leads to an unpack error in thermostat.py (line 74) again. 

As `self.topic_prefix` refers to "topic_prefix" in this example (class ThermostatWorker), we cannot strip "global_topic_prefix" because we have no access to it at this place. This patch adds the "global_topic_prefix" to the mqtt-Clients userdata (mqtt.py) so that it can be accessed in the callback wrapper (workers_manager.py). The callback wrapper is modified to centrally remove the global_prefix (if exists) before passing the topic to the real callback (the callbacks only sees the shortened prefix and unpack will work fine). The removal is still done using "len" as it might also contain additonal slashes and it should be safe to remove it from the beginning (https://stackoverflow.com/questions/16891340/remove-a-prefix-from-a-string/16891418).

I've tried it with and without a topic_prefix in the mqtt section and hope, that the patch will not lead to any problems as it has done before (sorry for the inconvenience).