### PR TITLE
mithermometer: Use cache for identical BTLE polls

### DIFF
--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -26,12 +26,9 @@ class MithermometerWorker(BaseWorker):
     return ret
 
   @timeout(8.0)
-
   def update_device_state(self, name, poller):
-
     ret = []
+    poller.clear_cache()
     for attr in monitoredAttrs:
-
-      ret.append(MqttMessage(topic=self.format_topic(name, attr), payload=poller.parameter_value(attr, read_cached=False)))
-
+      ret.append(MqttMessage(topic=self.format_topic(name, attr), payload=poller.parameter_value(attr)))
     return ret


### PR DESCRIPTION
Explicitly disabling the cache for each attribute leads to unnecessary BTLE queries. A response from the device for sensor-data always contains [both the temperature and humidity](https://github.com/hobbypunk90/mithermometer/blob/ec49fc3a6c67d383433194306a19f1cc03a50a76/mithermometer/mithermometer_poller.py#L173). With `read_cached=False` we force two separate BTLE queries instead of only one.

The proposed changes keeps the disabled cache but only clears it once before polling for attributes. The query for temperature polls the device for sensor data which in turn returns data for temperature and humidity and fills the cache. The subsequent query for humidity uses that cache.