### PR TITLE
Feature: On demand device polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ See [Wiki](https://github.com/zewelor/bt-mqtt-gateway/wiki) for more information
 * Highly extensible via custom workers
 * Data publication via MQTT
 * Configurable topic and payload
+* Support for on-demand device polling
 * MQTT authentication support
 * Systemd service
 * Reliable and intuitive
@@ -98,6 +99,18 @@ You need to define the absolute path of `gateway.py` in `bt-mqtt-gateway.service
 Use mosquitto_sub to print all messages
 ```
 mosquitto_sub -h localhost -d -t # command also help for me to test MQTT messages
+```
+
+**On-Demand Polling**
+To poll a device on demand (in addition to it's `update_interval`), publish an empty message at the `/poll` topic of the device.
+I.E:
+```
+# Will poll the scale
+mosquitto_pub -h localhost -t 'miscale/poll' -m ''
+# Will poll all MiFlora devices
+mosquitto_pub -h localhost -t 'miflora/poll' -m ''
+# Will poll the specified MiFlora device
+mosquitto_pub -h localhost -t 'miflora/herbs/poll' -m ''
 ```
 
 ## Custom worker development

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -23,12 +23,14 @@ class BlescanmultiWorker(BaseWorker):
 
     return None
 
-  def status_update(self):
+  def status_update(self, poll_device=None):
     scanner = Scanner().withDelegate(ScanDelegate())
     devices = scanner.scan(10.0)
     ret = []
 
     for name, mac in self.devices.items():
+      if poll_device and name != poll_device:
+        continue
       device = self.searchmac(devices, mac)
       if device is None:
         ret.append(MqttMessage(topic=self.format_topic('presence/'+name), payload="0"))

--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -15,9 +15,11 @@ class MifloraWorker(BaseWorker):
     for name, mac in self.devices.items():
       self.devices[name] = MiFloraPoller(mac, BluepyBackend, cache_timeout=0)
 
-  def status_update(self):
+  def status_update(self, poll_device=None):
     ret = []
     for name, poller in self.devices.items():
+      if poll_device and name != poll_device:
+        continue
       try:
         ret += self.update_device_state(name, poller)
       except RuntimeError:
@@ -26,7 +28,6 @@ class MifloraWorker(BaseWorker):
     return ret
 
   @timeout(8.0)
-
   def update_device_state(self, name, poller):
 
     ret = []

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -15,9 +15,11 @@ class MithermometerWorker(BaseWorker):
     for name, mac in self.devices.items():
       self.devices[name] = MiThermometerPoller(mac, BluepyBackend)
 
-  def status_update(self):
+  def status_update(self, poll_device=None):
     ret = []
     for name, poller in self.devices.items():
+      if poll_device and name != poll_device:
+        continue
       try:
         ret += self.update_device_state(name, poller)
       except RuntimeError:

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -62,11 +62,13 @@ class ThermostatWorker(BaseWorker):
 
     self._modes_mapper = self.ModesMapper()
 
-  def status_update(self):
+  def status_update(self, poll_device=None):
     from bluepy import btle
 
     ret = []
     for name, thermostat in self.devices.items():
+      if poll_device and name != poll_device:
+        continue
       try:
         ret += self.update_device_state(name, thermostat)
       except (RuntimeError, btle.BTLEException):

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -111,7 +111,7 @@ class WorkersManager:
       pip_main(['install', '-q', package])
 
   def _poll_wrapper(self, worker_obj, client, userdata, c):
-    if c.payload.decode('utf-8') != 'ON':
+    if c.payload.decode('utf-8') != '':
       return
     poll_device_supported = 'poll_device' in worker_obj.status_update.__code__.co_varnames
     topic_prefixes = []


### PR DESCRIPTION
# Description

This adds on-demand polling to the devices which support it.
It is used by publishing an empty MQTT message to the `/poll` topic of a device or device-type.

Usage examples:
```
# Will poll the scale
mosquitto_pub -h localhost -t 'miscale/poll' -m ''
# Will poll all MiFlora devices
mosquitto_pub -h localhost -t 'miflora/poll' -m ''
# Will poll the specified MiFlora device
mosquitto_pub -h localhost -t 'miflora/herbs/poll' -m ''
```
Motivation for this change:
It may be desirable to set a long `update_interval` to conserve battery, but situations can arise which require quicker updates.
An example of this would be using MiFlora devices, you may have them set to update once per 30mins-1hr, however when watering you may want to check their status on demand in order to prevent over-watering.
Or when using BLE tracking, you may want to dynamically poll based on attributes such as GPS location, movement or RSSI values.

I am also working on a PR to dynamically set the `update_interval` for devices.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (has been updated)
