### PR TITLE
Feature: dynamic update intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Use mosquitto_sub to print all messages
 mosquitto_sub -h localhost -d -t # command also help for me to test MQTT messages
 ```
 
+**Dynamically Changing the Update Interval**
+To dynamically change the `update_interval` of a worker, publish a message containing the new interval in seconds at the `update_interval` topic. Note that the `update_interval` will revert back to the value in `config.yaml` when the gateway is restarted.
+I.E:
+```
+# Set a new update interval of 3 minutes
+mosquitto_pub -h localhost -t 'miflora/update_interval' -m '150'
+# Set a new update interval of 30 seconds
+mosquitto_pub -h localhost -t 'mithermometer/update_interval' -m '30'
+```
+
 ## Custom worker development
 
 


### PR DESCRIPTION
# Description

This adds the ability to dynamically set the `update_interval` of a device via MQTT.
It is used by publishing a MQTT message containing the new `update_interval` in seconds to the `/update_interval` topic of a device-type.

Usage examples:
```
# Set a new update interval of 3 minutes
mosquitto_pub -h localhost -t 'miflora/update_interval' -m '150'
# Set a new update interval of 30 seconds
mosquitto_pub -h localhost -t 'mithermometer/update_interval' -m '30'
```
Motivation for this change:
It may be desirable to set a long `update_interval` to conserve battery, but situations can arise which require quicker updates.
An example of this would be using MiFlora devices, you may have them set to update once per 30mins-1hr, however when watering you may want to have their status update every minute.
Or when using BLE tracking, you may want to increase the update interval when certain events happen, such as geofences or movement detection.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (has been updated)
