### PR TITLE
miflora: Use cache for identical BTLE polls

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -11,9 +11,8 @@ class MifloraWorker(BaseWorker):
     from miflora.miflora_poller import MiFloraPoller
     from btlewrap.bluepy import BluepyBackend
 
-
     for name, mac in self.devices.items():
-      self.devices[name] = MiFloraPoller(mac, BluepyBackend, cache_timeout=0)
+      self.devices[name] = MiFloraPoller(mac, BluepyBackend)
 
   def status_update(self):
     ret = []
@@ -22,16 +21,12 @@ class MifloraWorker(BaseWorker):
         ret += self.update_device_state(name, poller)
       except RuntimeError:
         pass
-
     return ret
 
   @timeout(8.0)
-
   def update_device_state(self, name, poller):
-
     ret = []
+    poller.clear_cache()
     for attr in monitoredAttrs:
-
       ret.append(MqttMessage(topic=self.format_topic(name, attr), payload=poller.parameter_value(attr)))
-
     return ret


### PR DESCRIPTION
# Description

This is analogue to #38. A cache timeout of `0` leads to unnecessary BTLE queries.

Debug log of miflora per query before this change:
```
Filling cache with new sensor data.
Received result for handle %s: %s 56 5E 15 32 2E 37 2E 30
Received result for handle %s: %s 53 EA 00 00 A3 00 00 00 1A 36 00 02 3C 00 FB 34 9B
Filling cache with new sensor data.
Received result for handle %s: %s 53 EA 00 00 D5 00 00 00 1A 36 00 02 3C 00 FB 34 9B
Filling cache with new sensor data.
Received result for handle %s: %s 53 EA 00 00 02 01 00 00 1A 33 00 02 3C 00 FB 34 9B
Filling cache with new sensor data.
Received result for handle %s: %s 53 EA 00 00 B5 00 00 00 1A 35 00 02 3C 00 FB 34 9B
```

Debug log of miflora per query after this change:
```
Filling cache with new sensor data.
Received result for handle %s: %s 56 5D 15 32 2E 37 2E 30
Received result for handle %s: %s 53 D8 00 00 A2 00 00 00 17 3D 00 02 3C 00 FB 34 9B
Using cache (%s < %s) 0:00:00.005109 0:10:00
Using cache (%s < %s) 0:00:00.005528 0:10:00
Using cache (%s < %s) 0:00:00.006137 0:10:00
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
