### PR TITLE
blescanmulti - improve scanners options

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -54,6 +54,12 @@ manager:
           beacon: 00:11:22:33:44:55
           smartwath: 00:11:22:33:44:55
         topic_prefix: blescan
+        available_payload: home
+        unavailable_payload: not_home
+        available_timeout: 0
+        unavailable_timeout: 60
+        scan_timeout: 10
+        scan_passive: true
       update_interval: 60
     toothbrush:
       args:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,12 @@
+
+true_statement = ('y', 'yes', 'on', '1', 'true', 't', )
+
+
+def booleanize(value: str) -> bool:
+    """
+    This function will try to assume that provided string value is boolean in some way. It will accept a wide range
+    of values for strings like ('y', 'yes', 'on', '1', 'true' and 't'. Any other value will be treated as false
+    :param value: any value
+    :return: boolean statement
+    """
+    return value.lower() in true_statement

--- a/utils.py
+++ b/utils.py
@@ -2,11 +2,13 @@
 true_statement = ('y', 'yes', 'on', '1', 'true', 't', )
 
 
-def booleanize(value: str) -> bool:
+def booleanize(value) -> bool:
     """
     This function will try to assume that provided string value is boolean in some way. It will accept a wide range
     of values for strings like ('y', 'yes', 'on', '1', 'true' and 't'. Any other value will be treated as false
     :param value: any value
     :return: boolean statement
     """
-    return value.lower() in true_statement
+    if isinstance(value, str):
+        return value.lower() in true_statement
+    return bool(value)

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -43,9 +43,9 @@ class BlescanmultiWorker(BaseWorker):
     for name, mac in self.devices.items():
       device = self.searchmac(devices, mac)
       if device is None:
-        ret.append(MqttMessage(topic=self.format_topic('presence/'+name), payload="0"))
+        ret.append(MqttMessage(topic=self.format_topic('presence/'+name), payload=self.available_payload))
       else:
         ret.append(MqttMessage(topic=self.format_topic('presence/'+name+'/rssi'), payload=device.rssi))
-        ret.append(MqttMessage(topic=self.format_topic('presence/'+name), payload="1"))
+        ret.append(MqttMessage(topic=self.format_topic('presence/'+name), payload=self.unavailable_payload))
 
     return ret

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -28,6 +28,12 @@ class BlescanmultiWorker(BaseWorker):
   scan_timeout = 10.  # type: float
   scan_passive = True  # type: bool
 
+  def __init__(self, **kwargs):
+    super(BlescanmultiWorker, self).__init__(**kwargs)
+    self.last_status = {
+      device: (False, time.time()) for device in self.devices.keys()
+    }
+
   def searchmac(self, devices, mac):
     for dev in devices:
       if dev.addr == mac.lower():

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -63,12 +63,16 @@ class BleDeviceStatus:
 class BlescanmultiWorker(BaseWorker):
   # Default values
   devices = {}
+  # Payload that should be send when device is available
   available_payload = 'home'  # type: str
+  # Payload that should be send when device is unavailable
   unavailable_payload = 'not_home'  # type: str
+  # After what time (in seconds) we should inform that device is available (default: 0 seconds)
   available_timeout = 0  # type: float
+  # After what time (in seconds) we should inform that device is unavailable (default: 60 seconds)
   unavailable_timeout = 60  # type: float
   scan_timeout = 10.  # type: float
-  scan_passive = True  # type: bool
+  scan_passive = "true"  # type: str
 
   def __init__(self, **kwargs):
     super(BlescanmultiWorker, self).__init__(**kwargs)

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -76,9 +76,10 @@ class BlescanmultiWorker(BaseWorker):
 
   def __init__(self, **kwargs):
     super(BlescanmultiWorker, self).__init__(**kwargs)
-    self.last_status = {
-      device: (False, time.time()) for device in self.devices.keys()
-    }
+    self.scanner = Scanner().withDelegate(ScanDelegate())
+    self.last_status = [
+      BleDeviceStatus(self, name, mac) for name, mac in self.devices.values()
+    ]
 
   def searchmac(self, devices, mac):
     for dev in devices:
@@ -88,8 +89,7 @@ class BlescanmultiWorker(BaseWorker):
     return None
 
   def status_update(self):
-    scanner = Scanner().withDelegate(ScanDelegate())
-    devices = scanner.scan(float(self.scan_timeout), passive=booleanize(self.scan_passive))
+    devices = self.scanner.scan(float(self.scan_timeout), passive=booleanize(self.scan_passive))
     ret = []
 
     for name, mac in self.devices.items():

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -73,7 +73,7 @@ class BlescanmultiWorker(BaseWorker):
   # After what time (in seconds) we should inform that device is unavailable (default: 60 seconds)
   unavailable_timeout = 60  # type: float
   scan_timeout = 10.  # type: float
-  scan_passive = "true"  # type: str
+  scan_passive = True  # type: str or bool
 
   def __init__(self, **kwargs):
     super(BlescanmultiWorker, self).__init__(**kwargs)

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -15,7 +15,17 @@ class ScanDelegate(DefaultDelegate):
     if isNewDev:
       _LOGGER.debug("Discovered new device: %s" % dev.addr)
 
+
 class BlescanmultiWorker(BaseWorker):
+  # Default values
+  devices = {}
+  available_payload = 'home'  # type: str
+  unavailable_payload = 'not_home'  # type: str
+  available_timeout = 0  # type: float
+  unavailable_timeout = 60  # type: float
+  scan_timeout = 10.  # type: float
+  scan_passive = True  # type: bool
+
   def searchmac(self, devices, mac):
     for dev in devices:
       if dev.addr == mac.lower():

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -2,10 +2,12 @@ import time
 from interruptingcow import timeout
 from bluepy.btle import Scanner, DefaultDelegate
 from mqtt import MqttMessage
+from utils import booleanize
 from workers.base import BaseWorker
 from logger import _LOGGER
 
 REQUIREMENTS = ['bluepy']
+
 
 class ScanDelegate(DefaultDelegate):
   def __init__(self):
@@ -35,7 +37,7 @@ class BlescanmultiWorker(BaseWorker):
 
   def status_update(self):
     scanner = Scanner().withDelegate(ScanDelegate())
-    devices = scanner.scan(10.0)
+    devices = scanner.scan(float(self.scan_timeout), passive=booleanize(self.scan_passive))
     ret = []
 
     for name, mac in self.devices.items():

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -19,12 +19,13 @@ class ScanDelegate(DefaultDelegate):
 
 
 class BleDeviceStatus:
-  def __init__(self, worker, mac, name, available=False, last_status_time=None, message_sent=True):
+  def __init__(self, worker, mac: str, name: str, available: bool = False, last_status_time: float = None,
+               message_sent: bool = True):
     if last_status_time is None:
       last_status_time = time.time()
 
     self.worker = worker  # type: BlescanmultiWorker
-    self.mac = mac
+    self.mac = mac.lower()
     self.name = name
     self.available = available
     self.last_status_time = last_status_time

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -82,13 +82,6 @@ class BlescanmultiWorker(BaseWorker):
       BleDeviceStatus(self, name, mac) for name, mac in self.devices.items()
     ]
 
-  def searchmac(self, devices, mac):
-    for dev in devices:
-      if dev.addr == mac.lower():
-         return dev
-
-    return None
-
   def status_update(self):
     devices = self.scanner.scan(float(self.scan_timeout), passive=booleanize(self.scan_passive))
     mac_addresses = {

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -58,7 +58,7 @@ class BleDeviceStatus:
   def generate_message(self, device):
     if not self.message_sent and self.has_time_elapsed():
       self.message_sent = True
-      return MqttMessage(topic=device.format_topic('presence/{}'.format(self.name)), payload=self.payload())
+      return MqttMessage(topic=self.worker.format_topic('presence/{}'.format(self.name)), payload=self.payload())
 
 
 class BlescanmultiWorker(BaseWorker):

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -78,7 +78,7 @@ class BlescanmultiWorker(BaseWorker):
     super(BlescanmultiWorker, self).__init__(**kwargs)
     self.scanner = Scanner().withDelegate(ScanDelegate())
     self.last_status = [
-      BleDeviceStatus(self, name, mac) for name, mac in self.devices.values()
+      BleDeviceStatus(self, name, mac) for name, mac in self.devices.items()
     ]
 
   def searchmac(self, devices, mac):

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -79,7 +79,7 @@ class BlescanmultiWorker(BaseWorker):
     super(BlescanmultiWorker, self).__init__(**kwargs)
     self.scanner = Scanner().withDelegate(ScanDelegate())
     self.last_status = [
-      BleDeviceStatus(self, name, mac) for name, mac in self.devices.items()
+      BleDeviceStatus(self, mac, name) for name, mac in self.devices.items()
     ]
 
   def status_update(self):


### PR DESCRIPTION
# Description

Scanning ble tags for presence is looking like a good idea, but it can be a lot of problematic. At least 5 times during day beacon was not found by scanning, this result in instant mark person as not at home. Also by default it was using active way of scanning devices that force devices to resend discover info and if you do it too often it will drain battery very fast. Also this module is spamming MQTT by updating status each scan interval. I have rewrite this module and added extra options that allow you personalise everything. Starting from time of scan, mode of scanning and after what time of missing device we should send MQTT message with update

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
