### PR TITLE
Update dependencies to include btlewrap 0.0.4

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -5,7 +5,7 @@ from mqtt import MqttMessage
 from workers.base import BaseWorker
 import logger
 
-REQUIREMENTS = ['git+https://github.com/open-homeautomation/miflora.git@84f39432082796412d05b754c948499a1ad710e7#egg=miflora', 'bluepy']
+REQUIREMENTS = ['miflora', 'bluepy']
 monitoredAttrs = ["temperature", "moisture", "light", "conductivity", "battery"]
 _LOGGER = logger.get(__name__)
 

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -5,7 +5,7 @@ from mqtt import MqttMessage
 from workers.base import BaseWorker
 import logger
 
-REQUIREMENTS = ['mithermometer==0.1.2']
+REQUIREMENTS = ['git+https://github.com/cybe/mithermometer.git@cd8dba297927da823fbfa8f50bd97393ea6a93c1#egg=mithermometer']
 monitoredAttrs = ["temperature", "humidity", "battery"]
 _LOGGER = logger.get(__name__)
 


### PR DESCRIPTION
# Description

This updates miflora and mithermometer such that btlewrap 0.0.4 is included which fixes #39.

miflora got a proper release: open-homeautomation/miflora#117, so we can include that cleanly. mithermomether however not yet: hobbypunk90/mithermometer#2. Until this got merged, I include the source of that PR directly.

Is that temporary solution ok, @zewelor?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

