### PR TITLE
Configurable command timeout

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,8 +12,10 @@ manager:
     update_all:
       topic: homeassistant/status
       payload: online
+  command_timeout: 35           # Timeout for worker operations. Can be removed if the default of 35 seconds is sufficient.
   workers:
     mysensors:
+      command_timeout: 35       # Optional override of globally set command_timeout.
       args:
         port: /dev/ttyUSB0
         baudrate: 9600

--- a/gateway.py
+++ b/gateway.py
@@ -39,8 +39,8 @@ logger.suppress_update_failures(parsed.suppress)
 _LOGGER.info('Starting')
 
 mqtt = MqttClient(settings['mqtt'])
-manager = WorkersManager()
-manager.register_workers(settings['manager']).start(mqtt)
+manager = WorkersManager(settings['manager'])
+manager.register_workers().start(mqtt)
 
 running = True
 
@@ -49,8 +49,8 @@ while running:
     mqtt.publish(_WORKERS_QUEUE.get(timeout=10).execute())
   except queue.Empty: # Allow for SIGINT processing
     pass
-  except TimeoutError:
-    logger.log_exception(_LOGGER, "Timeout while executing worker command", suppress=True)
+  except TimeoutError as e:
+    logger.log_exception(_LOGGER, str(e) if str(e) else 'Timeout while executing worker command', suppress=True)
   except (KeyboardInterrupt, SystemExit):
     running = False
     _LOGGER.info('Finish current jobs and shut down. If you need force exit use kill')

--- a/workers/base.py
+++ b/workers/base.py
@@ -1,5 +1,6 @@
 class BaseWorker:
-  def __init__(self, **args):
+  def __init__(self, command_timeout, **args):
+    self.command_timeout = command_timeout
     for arg, value in args.items():
       setattr(self, arg, value)
     self._setup()

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -84,8 +84,8 @@ class BlescanmultiWorker(BaseWorker):
   scan_timeout = 10.  # type: float
   scan_passive = True  # type: str or bool
 
-  def __init__(self, **kwargs):
-    super(BlescanmultiWorker, self).__init__(**kwargs)
+  def __init__(self, command_timeout, **kwargs):
+    super(BlescanmultiWorker, self).__init__(command_timeout, **kwargs)
     self.scanner = Scanner().withDelegate(ScanDelegate())
     self.last_status = [
       BleDeviceStatus(self, mac, name) for name, mac in self.devices.items()

--- a/workers/linakdesk.py
+++ b/workers/linakdesk.py
@@ -6,6 +6,9 @@ from workers.base import BaseWorker
 REQUIREMENTS = ['git+https://github.com/zewelor/linak_bt_desk.git@aa9412f98b3044be34c70e89d02721e6813ea731#egg=linak_bt_desk']
 
 class LinakdeskWorker(BaseWorker):
+
+  SCAN_TIMEOUT = 20
+
   def _setup(self):
     from linak_dpg_bt import LinakDesk
 
@@ -15,7 +18,7 @@ class LinakdeskWorker(BaseWorker):
     return [MqttMessage(topic=self.format_topic('height/cm'), payload=self._get_height())]
 
   def _get_height(self):
-    with timeout(20, exception=TimeoutError):
+    with timeout(SCAN_TIMEOUT, exception=TimeoutError('Retrieving the height from {} device {} timed out after {} seconds'.format(repr(self), self.mac, SCAN_TIMEOUT))):
       self.desk.read_dpg_data()
       return self.desk.current_height_with_offset.cm
 

--- a/workers/miscale.py
+++ b/workers/miscale.py
@@ -11,6 +11,9 @@ REQUIREMENTS = ['bluepy']
 # sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/local/lib/python3.6/dist-packages/bluepy/bluepy-helper
 
 class MiscaleWorker(BaseWorker):
+
+  SCAN_TIMEOUT = 5
+
   def status_update(self):
     return [MqttMessage(topic=self.format_topic('weight/kg'), payload=self._get_weight())]
 
@@ -19,9 +22,9 @@ class MiscaleWorker(BaseWorker):
 
     scan_processor = ScanProcessor(self.mac)
     scanner = btle.Scanner().withDelegate(scan_processor)
-    scanner.scan(5, passive=True)
+    scanner.scan(SCAN_TIMEOUT, passive=True)
 
-    with timeout(5, exception=TimeoutError):
+    with timeout(SCAN_TIMEOUT, exception=TimeoutError('Retrieving the weight from {} device {} timed out after {} seconds'.format(repr(self), self.mac, SCAN_TIMEOUT))):
       while scan_processor.weight is None:
         time.sleep(1)
       return scan_processor.weight


### PR DESCRIPTION
Hey @zewelor 

# Description

This allows the timeout for commands to be configured through the `config.yaml` file. One can either configure this globally for all workers or individual per worker. Both is optional though, the default of 35 seconds is kept either way. Thus this change is fully backwards compatible to existing configurations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
