### PR TITLE
Hanging after timeout

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -30,6 +30,10 @@ class MifloraWorker(BaseWorker):
         ret += self.update_device_state(name, poller)
       except BluetoothBackendException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, poller._mac, type(e).__name__, suppress=True)
+        ret.append(MqttMessage(topic=self.format_topic(name, "problem"), payload="bluetooth problem"))
+      except TimeoutError as e:
+        logger.log_exception(_LOGGER, "Timeout during update of %s device '%s' (%s): %s", repr(self), name, poller._mac, type(e).__name__, suppress=True)
+        ret.append(MqttMessage(topic=self.format_topic(name, "problem"), payload="timeout"))
     return ret
 
   def update_device_state(self, name, poller):


### PR DESCRIPTION
# Description

After a timeout the miflora worker stucks.
with this changes the exception will be catched and a mqtt error message will added.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
