### PR TITLE
add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ADD ./start.sh /start.sh
 RUN chmod +x /start.sh
 
 ENV DEBUG false
-ENV TZ Europe/Berlin
 
 VOLUME ["/config"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apk add --no-cache tzdata python3 git bluez glib-dev make bluez-dev bluez-li
     mkdir /config && \
     pip install -r requirements.txt && \
     ln -s /config/config.yaml ./config.yaml && \
-    cp ./config.yaml.example /config/config.yaml.example && \
     apk del --no-cache bluez-dev musl-dev gcc make git glib-dev linux-headers grep python2
 
 RUN apk add --no-cache tzdata python3 git bluez glib-dev make bluez-dev bluez-libs musl-dev linux-headers gcc grep && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:3.8
+
+RUN mkdir application
+WORKDIR /application
+ADD . /application
+
+RUN apk add --no-cache tzdata python3 git bluez glib-dev make bluez-dev bluez-libs musl-dev linux-headers gcc grep && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then \
+      ln -s pip3 /usr/bin/pip ; \
+    fi && \
+    if [[ ! -e /usr/bin/python ]]; then \
+      ln -sf /usr/bin/python3 /usr/bin/python; \
+    fi && \
+    rm -r /root/.cache && \
+    mkdir /config && \
+    pip install -r requirements.txt && \
+    ln -s /config/config.yaml ./config.yaml && \
+    cp ./config.yaml.example /config/config.yaml.example && \
+    apk del --no-cache bluez-dev musl-dev gcc make git glib-dev linux-headers grep python2
+
+RUN apk add --no-cache tzdata python3 git bluez glib-dev make bluez-dev bluez-libs musl-dev linux-headers gcc grep && \
+    grep -P "(?<=REQUIREMENTS).*" workers/*.py | grep -Po "(?<=\[).*(?=\])" | tr ',' '\n' | tr "'" " "| tr "\"" " " > /tmp/requirements.txt && \
+    cat /tmp/requirements.txt && \
+    pip install -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt && \
+    apk del --no-cache bluez-dev musl-dev gcc make git glib-dev linux-headers grep python2
+
+ADD ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+ENV DEBUG false
+ENV TZ Europe/Berlin
+
+VOLUME ["/config"]
+
+ENTRYPOINT ["/bin/sh", "-c", "/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,17 @@
+ #!/bin/sh
+
+ if ! [ -f '/config/config.yaml' ]; then
+    echo "There is no config.yaml! An example is created."
+    cp /application/config.yaml.example /config/config.yaml.example
+    exit 1
+fi
+
+cd /application
+if [ "$DEBUG" = 'true' ]; then
+    echo "Start in debug mode"
+    python3 ./gateway.py -d
+    echo "Gateway died..."
+else
+    echo "Start in normal mode"
+    python3 ./gateway.py
+fi

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
  #!/bin/sh
 
- if ! [ -f '/config/config.yaml' ]; then
+if ! [ -f '/config/config.yaml' ]; then
     echo "There is no config.yaml! An example is created."
     cp /application/config.yaml.example /config/config.yaml.example
     exit 1
@@ -10,7 +10,9 @@ cd /application
 if [ "$DEBUG" = 'true' ]; then
     echo "Start in debug mode"
     python3 ./gateway.py -d
+    status=$?
     echo "Gateway died..."
+    exit $status
 else
     echo "Start in normal mode"
     python3 ./gateway.py


### PR DESCRIPTION
# Description

i add basically support for docker. 
with `docker build -t test/bt-mqtt-gateway .` you can build the container
and for example with `docker run -d --name bt-mqtt --network=host -v $PWD:/config test/bt-mqtt-gateway` you can run it as detached docker container 🙂

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
