### PR TITLE
add payload type for thermostat auto config

### DIFF
--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -100,18 +100,24 @@ class ThermostatWorker(BaseWorker):
     payload = {"unique_id": self.format_id(name, 'window_open', separator="_"),
                "state_topic": self.format_topic(name, 'window_open'),
                "device_class": 'window',
+               "payload_on": "True",
+               "payload_off": "False",
                "device": device}
     ret.append(MqttConfigMessage(MqttConfigMessage.BINARY_SENSOR, self.format_topic(name, 'window_open', separator="_"), payload=payload))
 
     payload = {"unique_id": self.format_id(name, 'low_battery', separator="_"),
                "state_topic": self.format_topic(name, 'low_battery'),
                "device_class": 'battery',
+               "payload_on": "True",
+               "payload_off": "False",
                "device": device}
     ret.append(MqttConfigMessage(MqttConfigMessage.BINARY_SENSOR, self.format_topic(name, 'low_battery', separator="_"), payload=payload))
 
     payload = {"unique_id": self.format_id(name, 'locked', separator="_"),
                "state_topic": self.format_topic(name, 'locked'),
                "device_class": 'lock',
+               "payload_on": "False",
+               "payload_off": "True",
                "device": device}
     ret.append(MqttConfigMessage(MqttConfigMessage.BINARY_SENSOR, self.format_topic(name, 'locked', separator="_"),
                                  payload=payload))


### PR DESCRIPTION
# Description

adds the payload_on and payload_off values for the "low_battery", "locked" and "window_open" sensors

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
