### PR TITLE
Support multiple slashes within topic prefix

### DIFF
--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -159,7 +159,8 @@ class ThermostatWorker(BaseWorker):
 
   def on_command(self, topic, value):
     from bluepy import btle
-    _, device_name, method, _ = topic.split('/')
+    topic_without_prefix = topic.replace('{}/'.format(self.topic_prefix), '')
+    device_name, method, _ = topic_without_prefix.split('/')
 
     data = self.devices[device_name]
 


### PR DESCRIPTION
# Description

Parsing of commands in `workers/thermostat.py` fail when the topic prefix contains slashes. This change subtracts the known topic prefix before extracting elements.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
