### PR TITLE
Make node id compatible with HA discovery

### DIFF
--- a/workers/base.py
+++ b/workers/base.py
@@ -8,7 +8,8 @@ class BaseWorker:
   def _setup(self):
     return
 
-  def format_discovery_topic(self, node_id, *sensor_args):
+  def format_discovery_topic(self, mac, *sensor_args):
+    node_id = mac.replace(':', '-')
     object_id = '_'.join([repr(self), *sensor_args])
     return '{}/{}'.format(node_id, object_id)
 


### PR DESCRIPTION
# Description

The recent merged PR #79 uses a MAC as a node id for home assistant auto discovery. However: As it turns out the `:` character is not [allowed](https://github.com/home-assistant/home-assistant/blob/0.96.3/homeassistant/components/mqtt/discovery.py#L18). This fixes the format by using `-` instead of `:`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
