### PR TITLE
HASS autodiscovery: Support current temperature topic and template

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -28,7 +28,11 @@ manager:
     thermostat:
       args:
         devices:
-          bedroom: 00:11:22:33:44:55
+          bedroom: 00:11:22:33:44:55  # Simple format
+          living_room:                # Extended format with additional configuration
+            mac: 00:11:22:33:44:55
+            discovery_temperature_topic: some/sensor/with/temperature       # Optional current_temperature_topic for HASS discovery
+            discovery_temperature_template: "{{ value_json.temperature }}"  # Optional current_temperature_template for HASS discovery
         topic_prefix: thermostat
       topic_subscription: thermostat/+/+/set
       update_interval: 60


### PR DESCRIPTION
# Description

The discovery feature creates a [MQTT HVAC](https://www.home-assistant.io/components/climate.mqtt/) device in HASS. As we know, the eQ-3 thermostat doesn't provide any temperature readings on its own. However, one can set a custom `current_temperature_topic` on the MQTT HVAC device and get the temperature from somewhere else, like a separate temperature sensor.

As the device configuration in HASS is originating from bt-mqtt-gateway, we have to set these options within bt-mqtt-gateway itself. This PR adds support for this use case.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
