### PR TITLE
Handle TimeoutError exception properly in mithermometer

### DIFF
--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -65,6 +65,8 @@ class MithermometerWorker(BaseWorker):
         ret += self.update_device_state(name, data["poller"])
       except BluetoothBackendException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
+      except TimeoutError as e:
+        logger.log_exception(_LOGGER, "Time out during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
     return ret
 
   def update_device_state(self, name, poller):


### PR DESCRIPTION
# Description

When having more than one device, if one was timing out, no device was
being updated. This was caused because the exception was not handled and the full worker was cancelled before sending the updates.

This PR fixes this, handling the exception properly, logging it but continuing by updating the devices that didn't time out.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
