### PR TITLE
Install packages using a virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.yaml
 __pycache__/
 .idea/
+.venv
 .vscode/

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ On a modern Linux system, just a few steps are needed to get the gateway working
 The following example shows the installation under Debian/Raspbian:
 
 ```shell
-sudo apt-get install git python3 python3-pip python3-wheel bluetooth bluez libglib2.0-dev
+sudo apt-get install git python3 python3-virtualenv python3-pip python3-wheel bluetooth bluez libglib2.0-dev
 git clone https://github.com/zewelor/bt-mqtt-gateway.git
 cd bt-mqtt-gateway
-sudo pip3 install -r requirements.txt
+virtualenv -p python3 .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
 ```
 
 ## Configuration
@@ -55,6 +57,7 @@ This file needs to be created first:
 ```shell
 cp config.yaml.example config.yaml
 vim config.yaml
+source .venv/bin/activate
 ./gateway.py
 ```
 
@@ -71,13 +74,14 @@ sudo hcitool lescan
 A test run is as easy as:
 
 ```shell
-sudo ./gateway.py
+source .venv/bin/activate
+./gateway.py
 ```
 
 Debug output can be displayed using the `-d` argument:
 
 ```shell
-sudo ./gateway.py -d
+./gateway.py -d
 ```
 
 ## Deployment
@@ -94,7 +98,7 @@ sudo systemctl enable bt-mqtt-gateway
 ```
 
 **Attention:**
-You need to define the absolute path of `gateway.py` in `bt-mqtt-gateway.service`.
+You need to define the absolute path of `service.sh` in `bt-mqtt-gateway.service`.
 
 **Testing mqtt:**
 Use mosquitto_sub to print all messages

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This file needs to be created first:
 cp config.yaml.example config.yaml
 vim config.yaml
 source .venv/bin/activate
-./gateway.py
+sudo ./gateway.py
 ```
 
 **Attention:**
@@ -75,13 +75,13 @@ A test run is as easy as:
 
 ```shell
 source .venv/bin/activate
-./gateway.py
+sudo ./gateway.py
 ```
 
 Debug output can be displayed using the `-d` argument:
 
 ```shell
-./gateway.py -d
+sudo ./gateway.py -d
 ```
 
 ## Deployment

--- a/bt-mqtt-gateway.service
+++ b/bt-mqtt-gateway.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/user/bt-mqtt-gateway
-ExecStart=/home/user/bt-mqtt-gateway/gateway.py
+ExecStart=/home/user/bt-mqtt-gateway/service.sh
 Restart=always
 
 [Install]

--- a/service.sh
+++ b/service.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR=$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )
+VIRTUAL_ENV=$SCRIPT_DIR/.venv
+if [ -d "$VIRTUAL_ENV" ]; then
+    export VIRTUAL_ENV
+    PATH="$VIRTUAL_ENV/bin:$PATH"
+    export PATH
+fi
+cd "$SCRIPT_DIR"
+python3 ./gateway.py "$@"


### PR DESCRIPTION
# Description

In order to avoid Python package conflicts on a system level (or just keeping the global installation clean) it is considered good practice to create virtual environments. This requires the additional Python package ``virtualenv`` to be installed globally, but removes the requirement to use ``sudo``.

This PR includes changes in installation instructions, and an additional script for running bt-mqtt-gateway as a systemd service. There is a new script ``service.sh`` which changes the Python path variables (which is essentially what Python virtualenv does). It still works if Python virtual environments are not used.
Modifying ``start.sh`` did not make sense for this purpose, since that script is used for starting a Docker container where virtual environments are redundant.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
