### PR TITLE
Support Home Assistant autodiscovery with global prefix

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -38,9 +38,11 @@ logger.suppress_update_failures(parsed.suppress)
 
 _LOGGER.info('Starting')
 
+global_topic_prefix = settings['mqtt'].get('topic_prefix')
+
 mqtt = MqttClient(settings['mqtt'])
 manager = WorkersManager(settings['manager'])
-manager.register_workers().start(mqtt)
+manager.register_workers(global_topic_prefix).start(mqtt)
 
 running = True
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -33,7 +33,10 @@ class MqttClient:
       return
 
     for m in messages:
-      topic = self._format_topic(m.topic)
+      if m.use_global_prefix:
+        topic = self._format_topic(m.topic)
+      else:
+        topic = m.topic
       self.mqttc.publish(topic, m.payload, retain=m.retain)
 
   @property
@@ -109,6 +112,8 @@ class MqttClient:
 
 
 class MqttMessage:
+  use_global_prefix = True
+
   def __init__(self, topic=None, payload=None, retain=False):
     self._topic = topic
     self._payload = payload
@@ -148,6 +153,8 @@ class MqttConfigMessage(MqttMessage):
   SENSOR = 'sensor'
   CLIMATE = 'climate'
   BINARY_SENSOR = 'binary_sensor'
+
+  use_global_prefix = False
 
   def __init__(self, component, name, payload=None, retain=False):
     super().__init__("{}/{}/config".format(component, name), json.dumps(payload), retain)

--- a/workers/base.py
+++ b/workers/base.py
@@ -1,7 +1,8 @@
 class BaseWorker:
-  def __init__(self, command_timeout, **args):
+  def __init__(self, command_timeout, global_topic_prefix, **kwargs):
     self.command_timeout = command_timeout
-    for arg, value in args.items():
+    self.global_topic_prefix = global_topic_prefix
+    for arg, value in kwargs.items():
       setattr(self, arg, value)
     self._setup()
 
@@ -21,6 +22,12 @@ class BaseWorker:
 
   def format_topic(self, *topic_args):
     return '/'.join([self.topic_prefix, *topic_args])
+
+  def format_prefixed_topic(self, *topic_args):
+    topic = self.format_topic(*topic_args)
+    if self.global_topic_prefix:
+      return '{}/{}'.format(self.global_topic_prefix, topic)
+    return topic
 
   def __repr__(self):
     return self.__module__.split(".")[-1]

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -84,8 +84,8 @@ class BlescanmultiWorker(BaseWorker):
   scan_timeout = 10.  # type: float
   scan_passive = True  # type: str or bool
 
-  def __init__(self, command_timeout, **kwargs):
-    super(BlescanmultiWorker, self).__init__(command_timeout, **kwargs)
+  def __init__(self, command_timeout, global_topic_prefix, **kwargs):
+    super(BlescanmultiWorker, self).__init__(command_timeout, global_topic_prefix, **kwargs)
     self.scanner = Scanner().withDelegate(ScanDelegate())
     self.last_status = [
       BleDeviceStatus(self, mac, name) for name, mac in self.devices.items()

--- a/workers/ibbq.py
+++ b/workers/ibbq.py
@@ -17,13 +17,6 @@ REQUIREMENTS = ['bluepy']
 
 
 class IbbqWorker(BaseWorker):
-
-  def __init__(self, command_timeout, **args):
-    self.command_timeout = command_timeout
-    for arg, value in args.items():
-      setattr(self, arg, value)
-    self._setup()
-
   def _setup(self):
     _LOGGER.info("Adding %d %s devices", len(self.devices), repr(self))
     for name, mac in self.devices.items():

--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -36,7 +36,7 @@ class MifloraWorker(BaseWorker):
     for attr in monitoredAttrs:
       payload = {
           "unique_id": self.format_discovery_id(mac, name, attr),
-          "state_topic": self.format_topic(name, attr),
+          "state_topic": self.format_prefixed_topic(name, attr),
           "name": self.format_discovery_name(name, attr),
           "device": device
       }

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -39,7 +39,7 @@ class MithermometerWorker(BaseWorker):
       payload = {
         "unique_id": self.format_discovery_id(mac, name, attr),
         "name": self.format_discovery_name(name, attr),
-        "state_topic": self.format_topic(name, attr),
+        "state_topic": self.format_prefixed_topic(name, attr),
         "device_class": attr,
         "device": device
       }

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -100,12 +100,12 @@ class ThermostatWorker(BaseWorker):
     payload = {"unique_id": self.format_discovery_id(mac, name, SENSOR_CLIMATE),
                "name": self.format_discovery_name(name, SENSOR_CLIMATE),
                "qos": 1,
-               "temperature_state_topic": self.format_topic(name, SENSOR_TARGET_TEMPERATURE),
-               "temperature_command_topic": self.format_topic(name, SENSOR_TARGET_TEMPERATURE, 'set'),
-               "mode_state_topic": self.format_topic(name, 'mode'),
-               "mode_command_topic": self.format_topic(name, 'mode', 'set'),
-               "away_mode_state_topic": self.format_topic(name, 'away'),
-               "away_mode_command_topic": self.format_topic(name, 'away', 'set'),
+               "temperature_state_topic": self.format_prefixed_topic(name, SENSOR_TARGET_TEMPERATURE),
+               "temperature_command_topic": self.format_prefixed_topic(name, SENSOR_TARGET_TEMPERATURE, 'set'),
+               "mode_state_topic": self.format_prefixed_topic(name, 'mode'),
+               "mode_command_topic": self.format_prefixed_topic(name, 'mode', 'set'),
+               "away_mode_state_topic": self.format_prefixed_topic(name, 'away'),
+               "away_mode_command_topic": self.format_prefixed_topic(name, 'away', 'set'),
                "min_temp": 5.0,
                "max_temp": 29.5,
                "temp_step": 0.5,
@@ -121,7 +121,7 @@ class ThermostatWorker(BaseWorker):
 
     payload = {"unique_id": self.format_discovery_id(mac, name, SENSOR_WINDOW),
                "name": self.format_discovery_name(name, SENSOR_WINDOW),
-               "state_topic": self.format_topic(name, SENSOR_WINDOW),
+               "state_topic": self.format_prefixed_topic(name, SENSOR_WINDOW),
                "device_class": 'window',
                "payload_on": "True",
                "payload_off": "False",
@@ -130,7 +130,7 @@ class ThermostatWorker(BaseWorker):
 
     payload = {"unique_id": self.format_discovery_id(mac, name, SENSOR_BATTERY),
                "name": self.format_discovery_name(name, SENSOR_BATTERY),
-               "state_topic": self.format_topic(name, SENSOR_BATTERY),
+               "state_topic": self.format_prefixed_topic(name, SENSOR_BATTERY),
                "device_class": 'battery',
                "payload_on": "True",
                "payload_off": "False",
@@ -139,7 +139,7 @@ class ThermostatWorker(BaseWorker):
 
     payload = {"unique_id": self.format_discovery_id(mac, name, SENSOR_LOCKED),
                "name": self.format_discovery_name(name, SENSOR_LOCKED),
-               "state_topic": self.format_topic(name, SENSOR_LOCKED),
+               "state_topic": self.format_prefixed_topic(name, SENSOR_LOCKED),
                "device_class": 'lock',
                "payload_on": "False",
                "payload_off": "True",
@@ -149,7 +149,7 @@ class ThermostatWorker(BaseWorker):
 
     payload = {"unique_id": self.format_discovery_id(mac, name, SENSOR_VALVE),
                "name": self.format_discovery_name(name, SENSOR_VALVE),
-               "state_topic": self.format_topic(name, SENSOR_VALVE),
+               "state_topic": self.format_prefixed_topic(name, SENSOR_VALVE),
                "unit_of_measurement": "%",
                "device": device}
     ret.append(MqttConfigMessage(MqttConfigMessage.SENSOR, self.format_discovery_topic(mac, name, SENSOR_VALVE), payload=payload))

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -45,7 +45,7 @@ class WorkersManager:
     self._config = config
     self._command_timeout = config.get('command_timeout', 35)
 
-  def register_workers(self):
+  def register_workers(self, global_topic_prefix):
     for (worker_name, worker_config) in self._config['workers'].items():
       module_obj = importlib.import_module("workers.%s" % worker_name)
       klass = getattr(module_obj, "%sWorker" % worker_name.title())
@@ -54,7 +54,7 @@ class WorkersManager:
         self._pip_install_helper(module_obj.REQUIREMENTS)
 
       command_timeout = worker_config.get('command_timeout', self._command_timeout)
-      worker_obj = klass(command_timeout, **worker_config['args'])
+      worker_obj = klass(command_timeout, global_topic_prefix, **worker_config['args'])
 
       if 'sensor_config' in self._config and hasattr(worker_obj, 'config'):
         _LOGGER.debug("Added %s config with a %d seconds timeout", repr(worker_obj), 2)


### PR DESCRIPTION
# Description

Setting the global topic prefix in ``mqtt`` -> ``topic_prefix`` is a good option for separating functionality of multiple gateways, and avoiding issues like #53.

The autodiscovery information sent to Home Assistant is however incorrect if the option is set. As a consequence, the devices appear but status information is not visible. There are two causes for the problem:

1. If the global prefix is set, the configuration messages' topics are prefixed with it. HASS is not going to receive them.
2. The worker method ``format_topic`` is not aware of the global prefix, so it does not include it when formatting the config message for HASS. As a result, HASS subscribes to the wrong topics and sends messages that no client is subscribed to.

This PR addresses both aforementioned issues.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
