### PR TITLE
Skip redundant Thermostat state update

### DIFF
--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -170,7 +170,7 @@ class ThermostatWorker(BaseWorker):
       except btle.BTLEException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
       else:
-        ret.extend(self.update_device_state(name, thermostat))
+        ret.extend(self.present_device_state(name, thermostat))
     return ret
 
   def on_command(self, topic, value):
@@ -200,9 +200,9 @@ class ThermostatWorker(BaseWorker):
       logger.log_exception(_LOGGER, "Error setting %s to %s on %s device '%s' (%s): %s", method, value, repr(self), device_name, data["mac"], type(e).__name__)
       return []
 
-    return self.update_device_state(device_name, thermostat)
+    return self.present_device_state(device_name, thermostat)
 
-  def update_device_state(self, name, thermostat):
+  def present_device_state(self, name, thermostat):
     ret = []
     for attr in monitoredAttrs:
       ret.append(MqttMessage(topic=self.format_topic(name, attr), payload=getattr(thermostat, attr)))


### PR DESCRIPTION
# Description

After submitting a command to a `ThermostatWorker` (e.g. change of temperature), a state update is requested from the underlying `Thermostat` instance before re-reading monitored attributes and reporting back via MQTT. I have observed however (using the `python-eq3bt` CLI in debug mode) that in the response of the initial command, the thermostat already returns a full status message which is immediately processed. As a consequence, the `Thermostat` instance is already up-to-date, making another `update` call redundant.

This PR removes the additional Bluetooth request, and simply re-uses the response already received directly after an attribute update. This made it necessary to separate the `Thermostat.update()` call from the rest of `update_device_state`. In return this speeds up the `ThermostatWorker` response and avoids delays in state updates due to a BT communication error in the second update cycle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
