### PR TITLE
Address "exec format error" in docker

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
- #!/bin/sh
+#!/bin/sh
 
 if ! [ -f '/config/config.yaml' ]; then
     echo "There is no config.yaml! An example is created."


### PR DESCRIPTION
# Description

The issue was essentially this, I'm running a raspberry pi:

```
$ docker-compose logs -f --tail=1000 bt2mqtt
Attaching to bt2mqtt
bt2mqtt          | standard_init_linux.go:211: exec user process caused "exec format error"
```

And then I looked closer and found this: https://www.lewuathe.com/exec-format-error-in-docker-container.html

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
