### PR TITLE
Return workers response asap

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,0 +1,2 @@
+DEFAULT_COMMAND_TIMEOUT = 35  # In seconds
+PER_DEVICE_TIMEOUT = 6        # In seconds

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,6 @@
+class WorkerTimeoutError(Exception):
+  pass
+
+
+class DeviceTimeoutError(Exception):
+  pass

--- a/gateway.py
+++ b/gateway.py
@@ -2,6 +2,8 @@
 
 import sys
 
+from exceptions import WorkerTimeoutError
+
 if sys.version_info < (3, 5):
   print("To use this script you need python 3.5 or newer! got %s" % sys.version_info)
   sys.exit(1)
@@ -51,7 +53,7 @@ while running:
     mqtt.publish(_WORKERS_QUEUE.get(timeout=10).execute())
   except queue.Empty: # Allow for SIGINT processing
     pass
-  except TimeoutError as e:
+  except WorkerTimeoutError as e:
     logger.log_exception(_LOGGER, str(e) if str(e) else 'Timeout while executing worker command', suppress=True)
   except (KeyboardInterrupt, SystemExit):
     running = False

--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -79,10 +79,9 @@ class MifloraWorker(BaseWorker):
       _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), name, data["mac"])
       from btlewrap import BluetoothBackendException
       try:
-        ret += self.update_device_state(name, data["poller"])
+        yield self.update_device_state(name, data["poller"])
       except BluetoothBackendException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
-    return ret
 
   def update_device_state(self, name, poller):
     ret = []

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -62,12 +62,11 @@ class MithermometerWorker(BaseWorker):
       _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), name, data["mac"])
       from btlewrap import BluetoothBackendException
       try:
-        ret += self.update_device_state(name, data["poller"])
+        yield self.update_device_state(name, data["poller"])
       except BluetoothBackendException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
       except TimeoutError as e:
         logger.log_exception(_LOGGER, "Time out during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
-    return ret
 
   def update_device_state(self, name, poller):
     ret = []

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -1,6 +1,7 @@
 import logging
 
 from mqtt import MqttMessage, MqttConfigMessage
+from interruptingcow import timeout
 
 from workers.base import BaseWorker
 import logger
@@ -9,6 +10,7 @@ REQUIREMENTS = ['mithermometer', 'bluepy']
 monitoredAttrs = ["temperature", "humidity", "battery"]
 _LOGGER = logger.get(__name__)
 
+PER_DEVICE_TIMEOUT = 6 # In seconds
 
 class MithermometerWorker(BaseWorker):
   def _setup(self):
@@ -68,6 +70,7 @@ class MithermometerWorker(BaseWorker):
       except TimeoutError as e:
         logger.log_exception(_LOGGER, "Time out during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
 
+  @timeout(PER_DEVICE_TIMEOUT, TimeoutError)
   def update_device_state(self, name, poller):
     ret = []
     poller.clear_cache()

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -1,5 +1,5 @@
-import logging
-
+from const import PER_DEVICE_TIMEOUT
+from exceptions import DeviceTimeoutError
 from mqtt import MqttMessage, MqttConfigMessage
 from interruptingcow import timeout
 
@@ -10,7 +10,6 @@ REQUIREMENTS = ['mithermometer', 'bluepy']
 monitoredAttrs = ["temperature", "humidity", "battery"]
 _LOGGER = logger.get(__name__)
 
-PER_DEVICE_TIMEOUT = 6 # In seconds
 
 class MithermometerWorker(BaseWorker):
   def _setup(self):
@@ -67,10 +66,10 @@ class MithermometerWorker(BaseWorker):
         yield self.update_device_state(name, data["poller"])
       except BluetoothBackendException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
-      except TimeoutError as e:
-        logger.log_exception(_LOGGER, "Time out during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
+      except DeviceTimeoutError as e:
+        logger.log_exception(_LOGGER, "Time out during update of %s device '%s' (%s)", repr(self), name, data["mac"], suppress=True)
 
-  @timeout(PER_DEVICE_TIMEOUT, TimeoutError)
+  @timeout(PER_DEVICE_TIMEOUT, DeviceTimeoutError)
   def update_device_state(self, name, poller):
     ret = []
     poller.clear_cache()

--- a/workers/switchbot.py
+++ b/workers/switchbot.py
@@ -19,8 +19,8 @@ class SwitchbotWorker(BaseWorker):
     _LOGGER.info("Adding %d %s devices", len(self.devices), repr(self))
     for name, mac in self.devices.items():
       _LOGGER.info("Adding %s device '%s' (%s)", repr(self), name, mac)
-      self.devices[name] = {"bot":None,"state":STATE_OFF,"mac":mac} 
-     
+      self.devices[name] = {"bot":None,"state":STATE_OFF,"mac":mac}
+
   def format_state_topic(self, *args):
     return '/'.join([self.state_topic_prefix, *args])
 
@@ -48,7 +48,7 @@ class SwitchbotWorker(BaseWorker):
     value = value.decode('utf-8')
 
     # It needs to be on separate if because first if can change method
-   
+
     _LOGGER.debug("Setting %s on %s device '%s' (%s)", value, repr(self), device_name, bot["mac"])
     try:
             bot["bot"] = Peripheral(bot["mac"],"random")
@@ -72,9 +72,7 @@ class SwitchbotWorker(BaseWorker):
       return []
 
   def update_device_state(self, name, value):
-    ret = []
-    ret.append(MqttMessage(topic=self.format_state_topic(name), payload=value))
-    return ret
+    return [MqttMessage(topic=self.format_state_topic(name), payload=value)]
 
   def device_for(self, mac):
     for key in self.devices:

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -160,7 +160,6 @@ class ThermostatWorker(BaseWorker):
   def status_update(self):
     from bluepy import btle
 
-    ret = []
     _LOGGER.info("Updating %d %s devices", len(self.devices), repr(self))
     for name, data in self.devices.items():
       _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), name, data["mac"])
@@ -170,8 +169,7 @@ class ThermostatWorker(BaseWorker):
       except btle.BTLEException as e:
         logger.log_exception(_LOGGER, "Error during update of %s device '%s' (%s): %s", repr(self), name, data["mac"], type(e).__name__, suppress=True)
       else:
-        ret.extend(self.present_device_state(name, thermostat))
-    return ret
+        yield self.present_device_state(name, thermostat)
 
   def on_command(self, topic, value):
     from bluepy import btle

--- a/workers/toothbrush.py
+++ b/workers/toothbrush.py
@@ -46,4 +46,4 @@ class ToothbrushWorker(BaseWorker):
         ret.append(MqttMessage(topic=self.format_topic(name+'/mode'), payload=bytes_[9] ))
         ret.append(MqttMessage(topic=self.format_topic(name+'/quadrant'), payload=bytes_[10] ))
 
-    return ret 
+      yield ret

--- a/workers/toothbrush_homeassistant.py
+++ b/workers/toothbrush_homeassistant.py
@@ -145,4 +145,4 @@ class Toothbrush_HomeassistantWorker(BaseWorker):
       if autoconf_data != False:
         ret.append(MqttMessage(topic=self.autodiscovery_prefix+"/sensor/"+self.topic_prefix+"_"+key+"/config", payload=json.dumps(autoconf_data), retain=True))
 
-    return ret
+      yield ret

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import threading
 from functools import partial
 import logging
@@ -31,7 +32,11 @@ class WorkersManager:
     def execute(self):
       messages = []
       with timeout(self._timeout, exception=TimeoutError('Execution of command {} timed out after {} seconds'.format(self._source, self._timeout))):
-        messages = self._callback(*self._args)
+        if inspect.isgeneratorfunction(self._callback):
+          for message in self._callback(*self._args):
+            messages += message
+        else:
+          messages = self._callback(*self._args)
 
       _LOGGER.debug('Execution result of command %s: %s', self._source, messages)
       return messages

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -19,7 +19,7 @@ else:
 
 _LOGGER = logger.get(__name__)
 
-DEFAULT_COMMAND_TIMEOUT = 3
+DEFAULT_COMMAND_TIMEOUT = 35
 
 class WorkersManager:
   class Command:

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -42,7 +42,7 @@ class WorkersManager:
             messages = self._callback(*self._args)
       except TimeoutError as e:
           if messages:
-            logger.log_exception(_LOGGER, str(e) if str(e) else 'Timeout while executing worker command, sending got only partial update', suppress=True)
+            _LOGGER.warn(f"{str(e)}, sending only partial update")
           else:
             raise e
 


### PR DESCRIPTION
# Description
When one device, in worker, timeouts, none of the messages from devices that responded, are being sent via mqtt. It should be fixed now.

Fixes #65, #95

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
