### PR TITLE
arm32v7 docker build setup

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,43 @@
+FROM alpine AS builder
+
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+FROM arm32v7/alpine:3.9
+
+COPY --from=builder qemu-arm-static /usr/bin
+RUN mkdir application
+WORKDIR /application
+ADD . /application
+
+RUN apk add --no-cache tzdata python3 git bluez glib-dev make bluez-dev bluez-libs musl-dev linux-headers gcc grep && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then \
+      ln -s pip3 /usr/bin/pip ; \
+    fi && \
+    if [[ ! -e /usr/bin/python ]]; then \
+      ln -sf /usr/bin/python3 /usr/bin/python; \
+    fi && \
+    rm -r /root/.cache && \
+    mkdir /config && \
+    pip install -r requirements.txt && \
+    ln -s /config/config.yaml ./config.yaml && \
+    apk del --no-cache bluez-dev musl-dev gcc make git glib-dev linux-headers grep python2
+
+RUN apk add --no-cache tzdata python3 git bluez glib-dev make bluez-dev bluez-libs musl-dev linux-headers gcc grep && \
+    grep -P "(?<=REQUIREMENTS).*" workers/*.py | grep -Po "(?<=\[).*(?=\])" | tr ',' '\n' | tr "'" " "| tr "\"" " " > /tmp/requirements.txt && \
+    cat /tmp/requirements.txt && \
+    pip install -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt && \
+    apk del --no-cache bluez-dev musl-dev gcc make git glib-dev linux-headers grep python2
+
+ADD ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+ENV DEBUG false
+
+VOLUME ["/config"]
+
+ENTRYPOINT ["/bin/sh", "-c", "/start.sh"]

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+./manifest-tool push from-spec multi-arch-manifest.yaml

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/multi-arch-manifest.yaml
+++ b/multi-arch-manifest.yaml
@@ -1,0 +1,11 @@
+image: zewelor/bt-mqtt-gateway:latest
+manifests:
+  - image: zewelor/bt-mqtt-gateway:amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: zewelor/bt-mqtt-gateway:arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7


### PR DESCRIPTION
# Description

This adds docker setup for arm32v7 architecture (with support of more potentially).

Partially implements #78.

A following build config change needs to be made on docker hub to make this work:

<img width="1030" alt="Docker Hub 2019-08-30 23-37-22" src="https://user-images.githubusercontent.com/944286/64049919-2b584100-cb7f-11e9-93bf-448dc87e4831.png">

"default" must be tagged amd64 and there's separate build step for arm32v7.

I used this guide mostly: https://github.com/ckulka/docker-multi-arch-example

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Notes

- I verified this setup in my own docker repo: https://hub.docker.com/r/krasnoukhov/bt-mqtt-gateway/builds
- After builds completed, I was able to use `image: krasnoukhov/bt-mqtt-gateway` in my docker-compose on raspberry pi with no additional config, thanks to manifest push
- I could not find a way to somehow reuse existing Dockerfile so I copied it (and adjusted to pull qemu in), maybe @hobbypunk90 has an idea on how to organize this better?
- I tried adding arm64v8 in the same fashion (using different [alpine](https://hub.docker.com/r/arm64v8/alpine/) images) but it just could not build with a weird failure right on `mkdir application`, not sure how to proceed with that, maybe someone can look into it later?
- Please note one of the initial builds will fail in `post_push` because there will be no tag for the manifest yet but the second build will succeed and bring everything in order