### PR TITLE
Compatibility for internal API change of pip >= 19.3.1

### DIFF
--- a/workers_manager.py
+++ b/workers_manager.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import threading
 from functools import partial
+from distutils.version import LooseVersion
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from interruptingcow import timeout
@@ -13,9 +14,11 @@ from workers_queue import _WORKERS_QUEUE
 import logger
 
 from pip import __version__ as pip_version
-
-if int(pip_version.split(".")[0]) >= 10:
-    from pip._internal import main as pip_main
+if LooseVersion(pip_version) >= LooseVersion("10"):
+    if LooseVersion(pip_version) >= LooseVersion("19.3.1"):
+        from pip._internal.main import main as pip_main
+    else:
+        from pip._internal import main as pip_main
 else:
     from pip import main as pip_main
 


### PR DESCRIPTION
# Description

pip >= 19.3.1 changed its internal API: https://github.com/pypa/pip/commit/09fd200c599de4fadf2ff814a1bef855bc6d77e8#diff-cf86c603e352099be697d1bd01c2d191

This resulted in the following error:
```Traceback (most recent call last):
  File "gateway.py", line 67, in <module>
    manager.register_workers(global_topic_prefix).start(mqtt)
  File "/bt-mqtt-gateway/workers_manager.py", line 82, in register_workers
    self._pip_install_helper(module_obj.REQUIREMENTS)
  File "/bt-mqtt-gateway/workers_manager.py", line 182, in _pip_install_helper
    pip_main(["install", "-q", package])
TypeError: 'module' object is not callable
```
This PR takes that API change into account.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
