### PR TITLE
Fix wrong miflora version in commit b379580

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -6,7 +6,7 @@ from interruptingcow import timeout
 from workers.base import BaseWorker
 import logger
 
-REQUIREMENTS = ["btlewrap==0.0.4", "miflora==0.0.5", "bluepy"]
+REQUIREMENTS = ["btlewrap==0.0.4", "miflora==0.5", "bluepy"]
 
 ATTR_BATTERY = "battery"
 ATTR_LOW_BATTERY = 'low_battery'


### PR DESCRIPTION
# Description

Commit b379580 changed the miflora version to 0.0.5, but this version doesn't exist. This pull request fixes it by changing it to 0.5, which seems to have been the intention. I confirmed that this works with my Xiaomi Mi Flora sensor.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
