### PR TITLE
Add support for second generation of Xiaomi climate sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See [Wiki](https://github.com/zewelor/bt-mqtt-gateway/wiki) for more information
 * [Switchbot](https://www.switch-bot.com/)
 * [Sensirion SmartGadget](https://www.sensirion.com/en/environmental-sensors/humidity-sensors/development-kit/) via [python-smartgadget](https://github.com/merll/python-smartgadget)
 * [RuuviTag](https://ruuvi.com/ruuvitag-specs/) via [ruuvitag-sensor](https://github.com/ttu/ruuvitag-sensor)
+* Xiaomi Mijia 2nd gen, aka LYWSD02
 
 ## Getting Started
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -110,4 +110,9 @@ manager:
           basement: 00:11:22:33:44:55
         topic_prefix: ruuvitag
       update_interval: 60
-
+    lywsd02:
+      args:
+        devices:
+          living_room:  00:11:22:33:44:55
+        topic_prefix: mijasensor
+      update_interval: 120

--- a/workers/lywsd02.py
+++ b/workers/lywsd02.py
@@ -1,0 +1,109 @@
+import json
+import logger
+
+from bluepy import btle
+from collections import namedtuple
+from contextlib import contextmanager
+from struct import unpack
+
+from mqtt import MqttMessage
+from workers.base import BaseWorker
+
+_LOGGER = logger.get(__name__)
+
+REQUIREMENTS = ["bluepy"]
+
+
+class Lywsd02Worker(BaseWorker):
+    def _setup(self):
+        _LOGGER.info("Adding %d %s devices", len(self.devices), repr(self))
+        for name, mac in self.devices.items():
+            _LOGGER.info("Adding %s device '%s' (%s)", repr(self), name, mac)
+            self.devices[name] = Lywsd02(mac, timeout=self.command_timeout)
+
+    def format_static_topic(self, *args):
+        return "/".join([self.topic_prefix, *args])
+
+    def status_update(self):
+        for name, lywsd02 in self.devices.items():
+            ret = lywsd02.readAll()
+
+            if not ret:
+                return []
+
+            return [
+                MqttMessage(
+                    topic=self.format_static_topic(name), payload=json.dumps(ret)
+                )
+            ]
+
+    def __repr__(self):
+        return self.__module__.split(".")[-1]
+
+
+class Lywsd02:
+    UUID_DATA = "ebe0ccc1-7a0a-4b0c-8a1a-6ff2997da3a6"
+    UUID_BATT = "ebe0ccc4-7a0a-4b0c-8a1a-6ff2997da3a6"
+
+    def __init__(self, mac, timeout=30):
+        self.mac = mac
+        self.timeout = timeout
+
+        self._temperature = None
+        self._humidity = None
+        self._battery = None
+
+    @contextmanager
+    def connected(self):
+        try:
+            _LOGGER.debug("%s connected ", self.mac)
+            device = btle.Peripheral()
+            device.connect(self.mac)
+            yield device
+            device.disconnect()
+        except btle.BTLEDisconnectError as er:
+            _LOGGER.debug("failed connect %s", er)
+            yield None
+
+    def readAll(self):
+        with self.connected() as device:
+            if not device:
+                return {}
+
+            temperature, humidity = self.getData(device)
+            battery = self.getBattery(device)
+            
+            _LOGGER.debug("successfully read %f, %d, %d", temperature, humidity, battery)
+
+            return {
+                "temperature": temperature,
+                "humidity": humidity,
+                "battery": battery,
+            }
+
+    def getData(self, device):
+        self.subscribe(device, self.UUID_DATA)
+        while True:
+            if device.waitForNotifications(self.timeout):
+                break
+        return self._temperature, self._humidity
+
+    def getBattery(self, device):
+        c = device.getCharacteristics(uuid=self.UUID_BATT)[0]
+        return ord(c.read())
+
+    def subscribe(self, device, uuid):
+        device.setDelegate(self)
+        c = device.getCharacteristics(uuid=uuid)[0]
+        d = c.getDescriptors(forUUID=0x2902)[0]
+
+        d.write(0x01.to_bytes(2, byteorder="little"), withResponse=True)
+
+    def processSensorsData(self, data):
+        self._temperature = unpack("H", data[:2])[0] / 100
+        self._humidity = data[2]
+
+    def handleNotification(self, handle, data):
+        # 0x4b is sensors data
+        if handle == 0x4b:
+            self.processSensorsData(data)


### PR DESCRIPTION
# Description

This includes clocks and dedicated temperature/humidity sensors family known as LYWSD02.

I got my hand on one of those literally for few hours and managed to make it work with bt-mqtt-gateway pretty easily. There's much more to implement, especially support for setting time, units (C/F) and maybe even history. That said - with this code it's possible to read it but it needs to be configured separately.

I structured the code similarty to IBBQ one, as it's pretty similar use case when we connect with bluepy.

```
2019-11-10 17:48:05,571 DEBUG bt-mqtt-gw.workers.lywsd02 lywsd02.py:59:connected - xx:xx:xx:xx:xx:xx connected
2019-11-10 17:48:25,924 DEBUG bt-mqtt-gw.workers.lywsd02 lywsd02.py:76:readAll - Read 21.820000, 60, 52
2019-11-10 17:48:25,931 DEBUG bt-mqtt-gw.workers_manager workers_manager.py:67:execute - Execution result of command Lywsd02Worker.status_update: [{'topic': 'miclock/clock01', 'payload': '{"temperature": 21.82, "humidity": 60, "battery": 52}'}]
```

As other xiaomi devices new devices also sometimes fail to connect. I've seen another PR that addresses retries, so dedicated retry logic is not included in this diff. Will wait and implement it properly once it's landed.

## Type of change

- New feature: added support for 2nd gen of Xiaomi bt sensors