### PR TITLE
More consistent state and hold mapping on EQ3

### DIFF
--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -226,7 +226,7 @@ class ThermostatWorker(BaseWorker):
                 STATE_OFF: Mode.Closed,
             }
             if value in state_mapping:
-                value = state_mapping.get(value)
+                value = state_mapping[value]
             else:
                 logger.log_exception(
                     _LOGGER,

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -311,7 +311,7 @@ class ThermostatWorker(BaseWorker):
         elif thermostat.target_temperature == thermostat.eco_temperature:
             hold = HOLD_ECO
         else:
-            hold = None
+            hold = HOLD_NONE
 
         ret.append(MqttMessage(topic=self.format_topic(name, "mode"), payload=mode))
         ret.append(MqttMessage(topic=self.format_topic(name, "hold"), payload=hold))

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -6,7 +6,7 @@ from mqtt import MqttMessage, MqttConfigMessage
 from workers.base import BaseWorker
 import logger
 
-REQUIREMENTS = ["python-eq3bt"]
+REQUIREMENTS = ["python-eq3bt==0.1.11"]
 _LOGGER = logger.get(__name__)
 
 STATE_HEAT = "heat"

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -221,7 +221,7 @@ class ThermostatWorker(BaseWorker):
         value = value.decode("utf-8")
         if method == "mode":
             mapping = {
-                STATE_HEAT: Mode.Boost,
+                STATE_HEAT: Mode.Manual,
                 STATE_AUTO: Mode.Auto,
                 STATE_OFF: Mode.Closed,
                 HOLD_BOOST: Mode.Boost,


### PR DESCRIPTION
# Description

Thanks to @krasnoukhov for implementing #121 and the modification of the MQTT component of Home Assistant. I had some issues using this however:
* Whenever setting the state to **Heat**, the thermostat activated **Boost** mode. Before #121, the thermostat changed to **Manual**, which is also the behavior of the [built-in **eq3btsmart** component](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/eq3btsmart/climate.py). The latter seems more predictable and appropriate to me. For setting boost mode, there is still the possibility to use the preset (hold mode).
* In my setup, neither of the presets **Eco** and **Comfort** worked as expected. They were directly linked to the thermostat state, but are actually separate concepts on the device as well. For example, it is possible to set the thermostat to **Eco** temperature, but leave the state at **Auto** so that the schedule will be considered again at the next programmed interval.

This PR changes the behavior as follows:
* HA's **Heat** state is mapped to the thermostat **Manual** mode again.
* Using presets **Comfort** and **Eco** has the same effect as setting them on the device directly, e.g. using the buttons, and does not change the thermostat's mode (**Manual**/**Auto**).
* Home Assistant shows if a preset temperature **Comfort** or **Eco** is currently set, regardless of how it was set.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
