### PR TITLE
Bump miflora to include btlewrap 0.0.9

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -6,7 +6,13 @@ from interruptingcow import timeout
 from workers.base import BaseWorker
 import logger
 
-REQUIREMENTS = ["miflora==0.6", "bluepy"]
+REQUIREMENTS = [
+    # Reference specific commit to include the transitive dependency
+    # btlewrap in version 0.0.9. This should be reverted to just
+    # "miflora" once miflora version > 0.6 is available on pypi.
+    "git+https://github.com/open-homeautomation/miflora.git@ebda66d1f4ba71bc0b98f8383280e59302b40fc8#egg=miflora",
+    "bluepy"
+]
 
 ATTR_BATTERY = "battery"
 ATTR_LOW_BATTERY = 'low_battery'


### PR DESCRIPTION
# Description

This change forces the inclusion of the transitive dependency `btlewrap` in version 0.0.9 to fix #108.  This should be reverted to just `miflora` once miflora version > 0.6 is available on [pypi](https://pypi.org/project/miflora/).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
