### PR TITLE
Bump mithermoter version

### DIFF
--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -6,7 +6,7 @@ from interruptingcow import timeout
 from workers.base import BaseWorker
 import logger
 
-REQUIREMENTS = ["mithermometer", "bluepy"]
+REQUIREMENTS = ["mithermometer==0.1.4", "bluepy"]
 monitoredAttrs = ["temperature", "humidity", "battery"]
 _LOGGER = logger.get(__name__)
 


### PR DESCRIPTION
# Description

Bump mithermometer, as it also uses btlewrap.

Fixes https://github.com/zewelor/bt-mqtt-gateway/issues/108