### PR TITLE
Add command to print all requirements, or configured only

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,5 +2,5 @@ import yaml
 import os
 import sys
 
-with open(os.path.join(sys.path[0], "config.yaml"), "r") as f:
+with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.yaml"), "r") as f:
     settings = yaml.safe_load(f)

--- a/workers/blescanmulti.py
+++ b/workers/blescanmulti.py
@@ -1,6 +1,5 @@
 import time
 
-from bluepy.btle import Scanner, DefaultDelegate
 from mqtt import MqttMessage
 
 from workers.base import BaseWorker
@@ -9,15 +8,6 @@ import logger
 
 REQUIREMENTS = ["bluepy"]
 _LOGGER = logger.get(__name__)
-
-
-class ScanDelegate(DefaultDelegate):
-    def __init__(self):
-        DefaultDelegate.__init__(self)
-
-    def handleDiscovery(self, dev, isNewDev, isNewData):
-        if isNewDev:
-            _LOGGER.debug("Discovered new device: %s" % dev.addr)
 
 
 class BleDeviceStatus:
@@ -99,6 +89,16 @@ class BlescanmultiWorker(BaseWorker):
     scan_passive = True  # type: str or bool
 
     def __init__(self, command_timeout, global_topic_prefix, **kwargs):
+        from bluepy.btle import Scanner, DefaultDelegate
+
+        class ScanDelegate(DefaultDelegate):
+            def __init__(self):
+                DefaultDelegate.__init__(self)
+
+            def handleDiscovery(self, dev, isNewDev, isNewData):
+                if isNewDev:
+                    _LOGGER.debug("Discovered new device: %s" % dev.addr)
+
         super(BlescanmultiWorker, self).__init__(
             command_timeout, global_topic_prefix, **kwargs
         )

--- a/workers/lywsd02.py
+++ b/workers/lywsd02.py
@@ -1,8 +1,6 @@
 import json
 import logger
 
-from bluepy import btle
-from collections import namedtuple
 from contextlib import contextmanager
 from struct import unpack
 
@@ -55,6 +53,8 @@ class Lywsd02:
 
     @contextmanager
     def connected(self):
+        from bluepy import btle
+
         try:
             _LOGGER.debug("%s connected ", self.mac)
             device = btle.Peripheral()
@@ -72,7 +72,7 @@ class Lywsd02:
 
             temperature, humidity = self.getData(device)
             battery = self.getBattery(device)
-            
+
             _LOGGER.debug("successfully read %f, %d, %d", temperature, humidity, battery)
 
             return {

--- a/workers/toothbrush.py
+++ b/workers/toothbrush.py
@@ -1,6 +1,5 @@
 import time
 
-from bluepy.btle import Scanner, DefaultDelegate
 from mqtt import MqttMessage
 
 from workers.base import BaseWorker
@@ -8,15 +7,6 @@ import logger
 
 REQUIREMENTS = ["bluepy"]
 _LOGGER = logger.get(__name__)
-
-
-class ScanDelegate(DefaultDelegate):
-    def __init__(self):
-        DefaultDelegate.__init__(self)
-
-    def handleDiscovery(self, dev, isNewDev, isNewData):
-        if isNewDev:
-            _LOGGER.debug("Discovered new device: %s" % dev.addr)
 
 
 class ToothbrushWorker(BaseWorker):
@@ -28,6 +18,16 @@ class ToothbrushWorker(BaseWorker):
         return None
 
     def status_update(self):
+        from bluepy.btle import Scanner, DefaultDelegate
+
+        class ScanDelegate(DefaultDelegate):
+            def __init__(self):
+                DefaultDelegate.__init__(self)
+
+            def handleDiscovery(self, dev, isNewDev, isNewData):
+                if isNewDev:
+                    _LOGGER.debug("Discovered new device: %s" % dev.addr)
+
         scanner = Scanner().withDelegate(ScanDelegate())
         devices = scanner.scan(5.0)
         ret = []

--- a/workers/toothbrush_homeassistant.py
+++ b/workers/toothbrush_homeassistant.py
@@ -1,7 +1,5 @@
-import time
 import json
 
-from bluepy.btle import Scanner, DefaultDelegate
 from mqtt import MqttMessage
 
 from workers.base import BaseWorker
@@ -50,15 +48,6 @@ BRUSHSECTORS = {
 }
 
 
-class ScanDelegate(DefaultDelegate):
-    def __init__(self):
-        DefaultDelegate.__init__(self)
-
-    def handleDiscovery(self, dev, isNewDev, isNewData):
-        if isNewDev:
-            _LOGGER.debug("Discovered new device: %s" % dev.addr)
-
-
 class Toothbrush_HomeassistantWorker(BaseWorker):
     def _setup(self):
         self.autoconfCache = {}
@@ -102,6 +91,16 @@ class Toothbrush_HomeassistantWorker(BaseWorker):
             return BRUSHSECTORS[255]
 
     def status_update(self):
+        from bluepy.btle import Scanner, DefaultDelegate
+
+        class ScanDelegate(DefaultDelegate):
+            def __init__(self):
+                DefaultDelegate.__init__(self)
+
+            def handleDiscovery(self, dev, isNewDev, isNewData):
+                if isNewDev:
+                    _LOGGER.debug("Discovered new device: %s" % dev.addr)
+
         scanner = Scanner().withDelegate(ScanDelegate())
         devices = scanner.scan(5.0)
         ret = []

--- a/workers_manager.py
+++ b/workers_manager.py
@@ -153,8 +153,6 @@ class WorkersManager:
                     )
                 )
 
-        return self
-
     def start(self, mqtt):
         mqtt.callbacks_subscription(self._mqtt_callbacks)
 

--- a/workers_requirements.py
+++ b/workers_requirements.py
@@ -1,0 +1,28 @@
+import importlib
+from pathlib import Path
+
+
+def configured_workers():
+    from config import settings
+
+    workers = settings['manager']['workers']
+    return _get_requirements(workers)
+
+
+def all_workers():
+    workers = map(lambda x: x.stem, Path('./workers').glob('*.py'))
+    return _get_requirements(workers)
+
+
+def _get_requirements(workers):
+    requirements = set()
+
+    for worker_name in workers:
+        module_obj = importlib.import_module("workers.%s" % worker_name)
+
+        try:
+            requirements.update(module_obj.REQUIREMENTS)
+        except AttributeError:
+            continue
+
+    return requirements


### PR DESCRIPTION
# Description

Added switch to list all requirements, from all workers, or from configured only. Also fixes for few workers, to import libs inside method calls.

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)