### PR TITLE
fix unknown device name in command message

### DIFF
--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -218,8 +218,12 @@ class ThermostatWorker(BaseWorker):
         topic_without_prefix = topic.replace("{}/".format(self.topic_prefix), "")
         device_name, method, _ = topic_without_prefix.split("/")
 
-        data = self.devices[device_name]
-        thermostat = data["thermostat"]
+        if device_name in self.devices:
+            data = self.devices[device_name]
+            thermostat = data["thermostat"]
+        else:
+            logger.log_exception(_LOGGER, "Ignore command because device %s is unknown", device_name)
+            return []
 
         value = value.decode("utf-8")
         if method == "mode":


### PR DESCRIPTION
# Description

Device names are retrieved by the configuration file. If an MQTT command is
handled but contains an unknown device name, which is not in the configuration
file a KeyError was thrown and the application was terminated. This commit
checks if the device name is known, if not it logs an error message but will not
fail.

Fixes KeyError exception #53 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
