### PR TITLE
Create a possibility to override default device timeout

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -72,6 +72,7 @@ manager:
         devices:
           living_room: 00:11:22:33:44:55
         topic_prefix: mithermometer
+        device_timeout: 6            # Optional override of globally set device_timeout.
       update_interval: 300
     blescanmulti:
       args:

--- a/const.py
+++ b/const.py
@@ -1,2 +1,2 @@
 DEFAULT_COMMAND_TIMEOUT = 35  # In seconds
-PER_DEVICE_TIMEOUT = 6  # In seconds
+DEFAULT_PER_DEVICE_TIMEOUT = 6  # In seconds

--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -1,4 +1,4 @@
-from const import PER_DEVICE_TIMEOUT
+from const import DEFAULT_PER_DEVICE_TIMEOUT
 from exceptions import DeviceTimeoutError
 from mqtt import MqttMessage, MqttConfigMessage
 
@@ -129,7 +129,7 @@ class MifloraWorker(BaseWorker):
                     suppress=True,
                 )
 
-    @timeout(PER_DEVICE_TIMEOUT, DeviceTimeoutError)
+    @timeout(DEFAULT_PER_DEVICE_TIMEOUT, DeviceTimeoutError)
     def update_device_state(self, name, poller):
         ret = []
         poller.clear_cache()

--- a/workers/mithermometer.py
+++ b/workers/mithermometer.py
@@ -1,4 +1,4 @@
-from const import PER_DEVICE_TIMEOUT
+from const import DEFAULT_PER_DEVICE_TIMEOUT
 from exceptions import DeviceTimeoutError
 from mqtt import MqttMessage, MqttConfigMessage
 from interruptingcow import timeout
@@ -12,6 +12,8 @@ _LOGGER = logger.get(__name__)
 
 
 class MithermometerWorker(BaseWorker):
+    device_timeout = DEFAULT_PER_DEVICE_TIMEOUT  # type: int
+
     def _setup(self):
         from mithermometer.mithermometer_poller import MiThermometerPoller
         from btlewrap.bluepy import BluepyBackend
@@ -73,7 +75,8 @@ class MithermometerWorker(BaseWorker):
             from btlewrap import BluetoothBackendException
 
             try:
-                yield self.update_device_state(name, data["poller"])
+                with timeout(self.device_timeout, exception=DeviceTimeoutError):
+                    yield self.update_device_state(name, data["poller"])
             except BluetoothBackendException as e:
                 logger.log_exception(
                     _LOGGER,
@@ -94,7 +97,6 @@ class MithermometerWorker(BaseWorker):
                     suppress=True,
                 )
 
-    @timeout(PER_DEVICE_TIMEOUT, DeviceTimeoutError)
     def update_device_state(self, name, poller):
         ret = []
         poller.clear_cache()


### PR DESCRIPTION
# Description

This PR adds an option to override the default device timeout in configuration file for mithermomether device. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
