### PR TITLE
Replace requirements installation at runtime with requirement verification

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -16,6 +16,7 @@ import logging
 import argparse
 import queue
 
+import workers_requirements
 from workers_queue import _WORKERS_QUEUE
 from mqtt import MqttClient
 from workers_manager import WorkersManager
@@ -51,8 +52,6 @@ parser.add_argument("-r", "--requirements", type=str, choices=['all', 'configure
 parsed = parser.parse_args()
 
 if parsed.requirements:
-    import workers_requirements
-
     requirements = []
     if parsed.requirements == 'configured':
         requirements = workers_requirements.configured_workers()
@@ -73,6 +72,8 @@ else:
 logger.suppress_update_failures(parsed.suppress)
 
 _LOGGER.info("Starting")
+
+workers_requirements.verify()
 
 global_topic_prefix = settings["mqtt"].get("topic_prefix")
 

--- a/workers_requirements.py
+++ b/workers_requirements.py
@@ -1,5 +1,11 @@
 import importlib
 from pathlib import Path
+import pkg_resources
+import re
+
+import logger
+
+_LOGGER = logger.get(__name__)
 
 
 def configured_workers():
@@ -12,6 +18,39 @@ def configured_workers():
 def all_workers():
     workers = map(lambda x: x.stem, Path('./workers').glob('*.py'))
     return _get_requirements(workers)
+
+
+def verify():
+    requirements = configured_workers()
+    egg = re.compile(r'.+#egg=(.+)$')
+
+    distributions = []
+    for req in requirements:
+        try:
+            pkg_resources.Requirement.parse(req)
+            distributions.append(req)
+        except (pkg_resources.extern.packaging.requirements.InvalidRequirement,
+                pkg_resources.RequirementParseError):
+            match = egg.match(req)
+            if match:
+                distributions.append(match.group(1))
+            else:
+                raise
+
+    errors = []
+    for dist in distributions:
+        try:
+            pkg_resources.require(dist)
+        except pkg_resources.ResolutionError as e:
+            errors.append(e.report())
+
+    if errors:
+        _LOGGER.error('Error: unsatisfied requirements:')
+        for error in errors:
+            _LOGGER.error('  %s', error)
+        _LOGGER.error('You may install those with pip: python -m pip install %s',
+                      ' '.join(requirements))
+        exit(1)
 
 
 def _get_requirements(workers):


### PR DESCRIPTION
# Description

1. Removes installation of configured requirements via pips [deprecated API](https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program) at runtime all together.
2. Verifies configured requirements on startup and prints a nice error message in case any requirements aren't met.

This might break existing setups, because the implementation now exits unconditionally when requirements are not met. Are there other conditions, where this could break something? How about Docker?

Fixes #184

Example for a fully fledged configuration:
```
13:00:16 Starting
13:00:16 Error: unsatisfied requirements:
13:00:16   The 'miflora' distribution was not found and is required by the application
13:00:16   The 'python-eq3bt==0.1.11' distribution was not found and is required by the application
13:00:16   The 'bluepy' distribution was not found and is required by the application
13:00:16   The 'ruuvitag_sensor' distribution was not found and is required by the application
13:00:16   The 'mithermometer==0.1.4' distribution was not found and is required by the application
13:00:16   The 'python-smartgadget' distribution was not found and is required by the application
13:00:16   The 'linakdpgbt' distribution was not found and is required by the application
13:00:16 You may install those with pip: python -m pip install git+https://github.com/open-homeautomation/miflora.git@ebda66d1f4ba71bc0b98f8383280e59302b40fc8#egg=miflora python-eq3bt==0.1.11 bluepy ruuvitag_sensor mithermometer==0.1.4 pyserial python-smartgadget git+https://github.com/zewelor/linak_bt_desk.git@aa9412f98b3044be34c70e89d02721e6813ea731#egg=linakdpgbt
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
