### PR TITLE
Add ARMv6 docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,4 +31,4 @@ jobs:
           [ "$VERSION" == "master" ] && VERSION=latest
           docker buildx build --push \
             --tag "${{ secrets.DOCKER_USERNAME }}"/${REPOSITORY_NAME}:${VERSION} \
-            --platform linux/amd64,linux/arm/v7,linux/arm64 .
+            --platform linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64 .


### PR DESCRIPTION
# Description

After this change github-actions would start building ARMv6 images in addition to existing ones.

I'm building my own cluster of RPi0, to use in home automation and the easiest way to deploy everything is to use Docker. Yeah, I know that it's crazy — to use Docker on rpi0, but anyway.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)