### PR TITLE
Am43 improvements pt2

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -158,10 +158,15 @@ manager:
         devices:
           upper_hall: 
             mac: 00:11:22:33:44:55
-            pin: 8888           # Pin code for the device
-            invert: true        # Set to true to make position 100 be open instead of the default of closed
+            pin: 8888             # Pin code for the device
+            invert: true          # Set to true to make position 100 be open instead of the default of closed
         topic_prefix: blinds
         per_device_timeout: 40
-        iface: 0                # Optional; you can get the list of available interfaces by calling `hciconfig`
+        iface: 0                  # Optional; you can get the list of available interfaces by calling `hciconfig`
+        rapid_update_interval: 10 # Optional; if set — the status of the device would be requested automatically after this value of seconds,
+                                  # if any activity was detected during the last update (or a command was executed)
+        default_update_interval: 300 # Optional; used together with `rapid_update_interval`, should have the same value as update_interval.
+                                     # when no changes detected after an update request, and `rapid_update_interval` is set, the update update_interval
+                                     # will be changed to `default_update_interval`.
       topic_subscription: blinds/+/+/+
       update_interval: 300

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -162,5 +162,6 @@ manager:
             invert: true        # Set to true to make position 100 be open instead of the default of closed
         topic_prefix: blinds
         per_device_timeout: 40
+        iface: 0                # Optional; you can get the list of available interfaces by calling `hciconfig`
       topic_subscription: blinds/+/+/+
       update_interval: 300

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -162,6 +162,7 @@ manager:
             invert: true          # Set to true to make position 100 be open instead of the default of closed
         topic_prefix: blinds
         per_device_timeout: 40
+        hass_device_class: blind  # Optional; the default will be "shade", see https://www.home-assistant.io/integrations/cover/#device-class for details
         iface: 0                  # Optional; you can get the list of available interfaces by calling `hciconfig`
         rapid_update_interval: 10 # Optional; if set — the status of the device would be requested automatically after this value of seconds,
                                   # if any activity was detected during the last update (or a command was executed)

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -113,8 +113,7 @@ class Am43Worker(BaseWorker):
                     self.last_target_position = shade.position
 
                 shade_position = self.correct_value(data, shade.position)
-                target_position = self.correct_value(
-                    data, self.last_target_position)
+                target_position = self.correct_value(data, self.last_target_position)
 
                 previous_position = self._last_position_by_device[data['mac']]
                 state = 'stopped'
@@ -139,8 +138,7 @@ class Am43Worker(BaseWorker):
                     "positionState": state,
                 }
             else:
-                _LOGGER.debug("Got battery state 0 for '%s' (%s)",
-                              device_name, data["mac"])
+                _LOGGER.debug("Got battery state 0 for '%s' (%s)", device_name, data["mac"])
 
     def create_mqtt_messages(self, device_name, device_state):
         return [
@@ -171,8 +169,7 @@ class Am43Worker(BaseWorker):
     def single_device_status_update(self, device_name, data):
         import Zemismart
 
-        _LOGGER.debug("Updating %s device '%s' (%s)",
-                      repr(self), device_name, data["mac"])
+        _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), device_name, data["mac"])
 
         shade = Zemismart.Zemismart(
             data["mac"], data["pin"], max_connect_time=self.per_device_timeout, withMutex=True)
@@ -182,8 +179,7 @@ class Am43Worker(BaseWorker):
                 device_state = self.get_device_state(device_name, data, shade)
                 ret += self.create_mqtt_messages(device_name, device_state)
 
-                if not device_state['positionState'].endswith(
-                        'ing') and self.default_update_interval != self.update_interval:
+                if device_state['positionState'].endswith('ing') and self.default_update_interval == self.update_interval:
                     ret.append(
                         MqttMessage(
                             topic=self.format_topic('update_interval'),
@@ -234,10 +230,8 @@ class Am43Worker(BaseWorker):
                                         withMutex=True)
             try:
                 with shade:
-                    device_state = self.get_device_state(
-                        device_name, data, shade)
-                    device_position = self.correct_value(
-                        data, device_state["currentPosition"])
+                    device_state = self.get_device_state(device_name, data, shade)
+                    device_position = self.correct_value(data, device_state["currentPosition"])
 
                     if value == 'STOP':
                         shade.stop()
@@ -257,8 +251,7 @@ class Am43Worker(BaseWorker):
                                 )
                             )
 
-                        ret += self.create_mqtt_messages(
-                            device_name, device_state)
+                        ret += self.create_mqtt_messages(device_name, device_state)
                     elif value == 'OPEN' and device_position > self.target_range_scale:
                         # Yes, for open command we need to call close(), because "closed blinds" in AM43
                         # means that they're hidden, and the window is full open
@@ -280,8 +273,7 @@ class Am43Worker(BaseWorker):
                                 )
                             )
 
-                        ret += self.create_mqtt_messages(
-                            device_name, device_state)
+                        ret += self.create_mqtt_messages(device_name, device_state)
                     elif value == 'CLOSE' and device_position < 100 - self.target_range_scale:
                         # Same as above for 'OPEN': we need to call open() when want to close() the window
                         shade.open()
@@ -293,8 +285,7 @@ class Am43Worker(BaseWorker):
                         }
                         self.last_target_position = 100
 
-                        ret += self.create_mqtt_messages(
-                            device_name, device_state)
+                        ret += self.create_mqtt_messages(device_name, device_state)
 
                         if self.default_update_interval:
                             self.update_interval = 3
@@ -335,10 +326,8 @@ class Am43Worker(BaseWorker):
                     # get the current state so we can work out direction for update messages
                     # after getting this, convert so we are using the device scale for
                     # values
-                    device_state = self.get_device_state(
-                        device_name, data, shade)
-                    device_position = self.correct_value(
-                        data, device_state["currentPosition"])
+                    device_state = self.get_device_state(device_name, data, shade)
+                    device_position = self.correct_value(data, device_state["currentPosition"])
 
                     if device_position == target_position:
                         # no update required, not moved

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -4,7 +4,7 @@ import time
 import logger
 from const import DEFAULT_PER_DEVICE_TIMEOUT
 from mqtt import MqttMessage, MqttConfigMessage
-from workers.base import BaseWorker
+from workers.base import BaseWorker, retry
 
 _LOGGER = logger.get(__name__)
 
@@ -20,10 +20,8 @@ class Am43Worker(BaseWorker):
     last_target_position = 255
 
     def _setup(self):
-        self._last_position_by_device = {
-            device['mac']: 255 for device in self.devices.values()}
-        self._last_device_update = {
-            device['mac']: 0 for device in self.devices.values()}
+        self._last_position_by_device = {device['mac']: 255 for device in self.devices.values()}
+        self._last_device_update = {device['mac']: 0 for device in self.devices.values()}
 
         if not hasattr(self, 'default_update_interval'):
             self.default_update_interval = None
@@ -97,7 +95,7 @@ class Am43Worker(BaseWorker):
     def get_device_state(self, device_name, data, shade):
         battery = 0
         retry_attempts = 0
-        while battery == 0 and retry_attempts < 5:
+        while battery == 0 and retry_attempts < self.update_retries:
             retry_attempts += 1
 
             # The docs for this library say that sometimes this needs called
@@ -173,63 +171,187 @@ class Am43Worker(BaseWorker):
         ]
 
     def single_device_status_update(self, device_name, data):
-        import Zemismart
-
         _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), device_name, data["mac"])
 
-        shade = Zemismart.Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
-                                    withMutex=True, iface=data.get('iface'))
-        try:
-            with shade:
-                ret = []
-                device_state = self.get_device_state(device_name, data, shade)
-                ret += self.create_mqtt_messages(device_name, device_state)
+        from Zemismart import Zemismart
+        shade = Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
+                          withMutex=True, iface=data.get('iface'))
+        with shade:
+            ret = []
+            device_state = self.get_device_state(device_name, data, shade)
+            ret += self.create_mqtt_messages(device_name, device_state)
 
-                if device_state['positionState'].endswith('ing') and self.default_update_interval == self.update_interval:
-                    ret.append(
-                        MqttMessage(
-                            topic=self.format_topic('update_interval'),
-                            payload=3
-                        )
+            if device_state['positionState'].endswith('ing') and self.default_update_interval == self.update_interval:
+                ret.append(
+                    MqttMessage(
+                        topic=self.format_topic('update_interval'),
+                        payload=3
                     )
-                    self.update_interval = 3
-                elif not device_state['positionState'].endswith('ing') and self.default_update_interval != self.update_interval:
+                )
+                self.update_interval = 3
+            elif not device_state['positionState'].endswith('ing') and self.default_update_interval != self.update_interval:
+                ret.append(
+                    MqttMessage(
+                        topic=self.format_topic('update_interval'),
+                        payload=self.default_update_interval
+                    )
+                )
+                self.update_interval = self.default_update_interval
+
+            return ret
+
+    def status_update(self):
+        _LOGGER.info("Updating %d %s devices", len(self.devices), repr(self))
+
+        for device_name, data in self.devices.items():
+            yield retry(self.single_device_status_update, retries=self.update_retries)(device_name, data)
+
+    def set_state(self, state, device_name):
+        from Zemismart import Zemismart
+
+        ret = []
+        data = self.devices[device_name]
+        shade = Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
+                          withMutex=True, iface=data.get('iface'))
+        with shade:
+            device_state = self.get_device_state(device_name, data, shade)
+            device_position = self.correct_value(data, device_state["currentPosition"])
+
+            if state == 'STOP':
+                if not shade.stop():
+                    raise AttributeError('shade.stop() failed')
+
+                device_state = {
+                    "currentPosition": device_position,
+                    "targetPosition": device_position,
+                    "battery": shade.battery,
+                    "positionState": 'stopped'
+                }
+                self.last_target_position = device_position
+
+                if self.default_update_interval:
+                    self.update_interval = self.default_update_interval
                     ret.append(
                         MqttMessage(
                             topic=self.format_topic('update_interval'),
                             payload=self.default_update_interval
                         )
                     )
-                    self.update_interval = self.default_update_interval
 
-                return ret
-        except AttributeError as e:
-            # This type of error can be thrown from time to time if the underlying
-            # zemismart library doesn't connect correctly
-            logger.log_exception(
-                _LOGGER,
-                "Error during update of %s device '%s' (%s): %s",
-                repr(self),
-                device_name,
-                data["mac"],
-                type(e).__name__,
-                suppress=True,
-            )
+                ret += self.create_mqtt_messages(device_name, device_state)
+            elif state == 'OPEN' and device_position > self.target_range_scale:
+                shade.stop()
 
-        return []
+                # Yes, for open command we need to call close(), because "closed blinds" in AM43
+                # means that they're hidden, and the window is full open
+                if not shade.close():
+                    raise AttributeError('shade.close() failed')
+                device_state = {
+                    "currentPosition": device_position,
+                    "targetPosition": 0,
+                    "battery": shade.battery,
+                    "positionState": 'opening'
+                }
+                self.last_target_position = 0
 
-    def status_update(self):
-        _LOGGER.info("Updating %d %s devices", len(self.devices), repr(self))
+                if self.default_update_interval:
+                    self.update_interval = 3
+                    ret.append(
+                        MqttMessage(
+                            topic=self.format_topic('update_interval'),
+                            payload=3
+                        )
+                    )
 
-        for device_name, data in self.devices.items():
-            yield self.single_device_status_update(device_name, data)
+                ret += self.create_mqtt_messages(device_name, device_state)
+            elif state == 'CLOSE' and device_position < 100 - self.target_range_scale:
+                shade.stop()
 
-    def on_command(self, topic, value):
-        _LOGGER.info("On command called with %s %s", topic, value)
-        import Zemismart
+                # Same as above for 'OPEN': we need to call open() when want to close() the window
+                if not shade.open():
+                    raise AttributeError('shade.open() failed')
+                device_state = {
+                    "currentPosition": device_position,
+                    "targetPosition": 100,
+                    "battery": shade.battery,
+                    "positionState": 'closing'
+                }
+                self.last_target_position = 100
 
-        topic_without_prefix = topic.replace(
-            "{}/".format(self.topic_prefix), "")
+                ret += self.create_mqtt_messages(device_name, device_state)
+
+                if self.default_update_interval:
+                    self.update_interval = 3
+                    ret.append(
+                        MqttMessage(
+                            topic=self.format_topic('update_interval'),
+                            payload=3
+                        )
+                    )
+        return ret
+
+    def set_position(self, position, device_name):
+        from Zemismart import Zemismart
+
+        ret = []
+
+        # internal state of the target position should align with the scale used by the
+        # device
+        if self.target_range_scale <= int(position) <= 100 - self.target_range_scale:
+            position = int((int(position) - self.target_range_scale) * (100 / (100 - self.target_range_scale * 2)))
+
+        data = self.devices[device_name]
+        target_position = self.correct_value(data, int(position))
+        self.last_target_position = target_position
+
+        shade = Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
+                          withMutex=True, iface=data.get('iface'))
+        with shade:
+            # get the current state so we can work out direction for update messages
+            # after getting this, convert so we are using the device scale for
+            # values
+            device_state = self.get_device_state(device_name, data, shade)
+            device_position = self.correct_value(data, device_state["currentPosition"])
+
+            if device_position == target_position:
+                # no update required, not moved
+                _LOGGER.debug("Position for device '%s' (%s) matches, %s %s",
+                              device_name, data["mac"], device_position, position)
+                return []
+            else:
+                # work out the direction
+                # this compares the values using the caller scale instead
+                # of the internal scale.
+                if device_state["currentPosition"] < int(position):
+                    state = "closing"
+                else:
+                    state = "opening"
+
+                # send the new position
+                if not shade.set_position(target_position):
+                    raise AttributeError('shade.set_position() failed')
+
+                device_state = {
+                    "currentPosition": device_position,
+                    "targetPosition": target_position,
+                    "battery": shade.battery,
+                    "positionState": state
+                }
+
+                ret += self.create_mqtt_messages(device_name, device_state)
+
+                if self.default_update_interval:
+                    self.update_interval = 3
+                    ret.append(
+                        MqttMessage(
+                            topic=self.format_topic('update_interval'),
+                            payload=3
+                        )
+                    )
+        return ret
+
+    def handle_mqtt_command(self, topic, value):
+        topic_without_prefix = topic.replace("{}/".format(self.topic_prefix), "")
         device_name, field, action = topic_without_prefix.split("/")
         ret = []
 
@@ -237,174 +359,19 @@ class Am43Worker(BaseWorker):
             data = self.devices[device_name]
             _LOGGER.debug("On command got device %s %s", device_name, data)
         else:
-            logger.log_exception(
-                _LOGGER, "Ignore command because device %s is unknown", device_name)
+            _LOGGER.error("Ignore command because device %s is unknown", device_name)
             return ret
 
         value = value.decode("utf-8")
         if field == "positionState" and action == "set":
-            shade = Zemismart.Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
-                                        withMutex=True, iface=data.get('iface'))
-            try:
-                with shade:
-                    device_state = self.get_device_state(device_name, data, shade)
-                    device_position = self.correct_value(data, device_state["currentPosition"])
-
-                    if value == 'STOP':
-                        if not shade.stop():
-                            raise AttributeError('shade.stop() failed')
-
-                        device_state = {
-                            "currentPosition": device_position,
-                            "targetPosition": device_position,
-                            "battery": shade.battery,
-                            "positionState": 'stopped'
-                        }
-                        self.last_target_position = device_position
-
-                        if self.default_update_interval:
-                            self.update_interval = self.default_update_interval
-                            ret.append(
-                                MqttMessage(
-                                    topic=self.format_topic('update_interval'),
-                                    payload=self.default_update_interval
-                                )
-                            )
-
-                        ret += self.create_mqtt_messages(device_name, device_state)
-                    elif value == 'OPEN' and device_position > self.target_range_scale:
-                        shade.stop()
-
-                        # Yes, for open command we need to call close(), because "closed blinds" in AM43
-                        # means that they're hidden, and the window is full open
-                        if not shade.close():
-                            raise AttributeError('shade.close() failed')
-                        device_state = {
-                            "currentPosition": device_position,
-                            "targetPosition": 0,
-                            "battery": shade.battery,
-                            "positionState": 'opening'
-                        }
-                        self.last_target_position = 0
-
-                        if self.default_update_interval:
-                            self.update_interval = 3
-                            ret.append(
-                                MqttMessage(
-                                    topic=self.format_topic('update_interval'),
-                                    payload=3
-                                )
-                            )
-
-                        ret += self.create_mqtt_messages(device_name, device_state)
-                    elif value == 'CLOSE' and device_position < 100 - self.target_range_scale:
-                        shade.stop()
-
-                        # Same as above for 'OPEN': we need to call open() when want to close() the window
-                        if not shade.open():
-                            raise AttributeError('shade.open() failed')
-                        device_state = {
-                            "currentPosition": device_position,
-                            "targetPosition": 100,
-                            "battery": shade.battery,
-                            "positionState": 'closing'
-                        }
-                        self.last_target_position = 100
-
-                        ret += self.create_mqtt_messages(device_name, device_state)
-
-                        if self.default_update_interval:
-                            self.update_interval = 3
-                            ret.append(
-                                MqttMessage(
-                                    topic=self.format_topic('update_interval'),
-                                    payload=3
-                                )
-                            )
-            except AttributeError as e:
-                # This type of error can be thrown from time to time if the underlying
-                # zemismart library doesn't connect correctly
-                logger.log_exception(
-                    _LOGGER,
-                    "Error setting %s to %s on %s device '%s' (%s): %s",
-                    field,
-                    value,
-                    repr(self),
-                    device_name,
-                    data["mac"],
-                    type(e).__name__,
-                )
+            ret += self.set_state(value, device_name)
         elif field == "targetPosition" and action == "set":
-            # internal state of the target position should align with the scale used by the
-            # device
-
-            if self.target_range_scale <= int(value) <= 100 - self.target_range_scale:
-                value = int((int(value) - self.target_range_scale)
-                            * (100 / (100 - self.target_range_scale * 2)))
-
-            target_position = self.correct_value(data, int(value))
-            self.last_target_position = target_position
-
-            shade = Zemismart.Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
-                                        withMutex=True, iface=data.get('iface'))
-            try:
-                with shade:
-                    # get the current state so we can work out direction for update messages
-                    # after getting this, convert so we are using the device scale for
-                    # values
-                    device_state = self.get_device_state(device_name, data, shade)
-                    device_position = self.correct_value(data, device_state["currentPosition"])
-
-                    if device_position == target_position:
-                        # no update required, not moved
-                        _LOGGER.debug("Position for device '%s' (%s) matches, %s %s",
-                                      device_name, data["mac"], device_position, value)
-                        return []
-                    else:
-                        # work out the direction
-                        # this compares the values using the caller scale instead
-                        # of the internal scale.
-                        if device_state["currentPosition"] < int(value):
-                            state = "closing"
-                        else:
-                            state = "opening"
-
-                        # send the new position
-                        if not shade.set_position(target_position):
-                            raise AttributeError('shade.set_position() failed')
-
-                        device_state = {
-                            "currentPosition": device_position,
-                            "targetPosition": target_position,
-                            "battery": shade.battery,
-                            "positionState": state
-                        }
-
-                        ret += self.create_mqtt_messages(
-                            device_name, device_state)
-
-                        if self.default_update_interval:
-                            self.update_interval = 3
-                            ret.append(
-                                MqttMessage(
-                                    topic=self.format_topic('update_interval'),
-                                    payload=3
-                                )
-                            )
-            except AttributeError as e:
-                # This type of error can be thrown from time to time if the underlying
-                # zemismart library doesn't connect correctly
-                logger.log_exception(
-                    _LOGGER,
-                    "Error setting %s to %s on %s device '%s' (%s): %s",
-                    field,
-                    value,
-                    repr(self),
-                    device_name,
-                    data["mac"],
-                    type(e).__name__,
-                )
+            ret += self.set_position(value, device_name)
         elif field == "get" or action == "get":
-            ret += self.single_device_status_update(device_name, data)
+            ret += retry(self.single_device_status_update, retries=self.update_retries)(device_name, data)
 
         return ret
+
+    def on_command(self, topic, value):
+        _LOGGER.info("On command called with %s %s", topic, value)
+        return retry(self.handle_mqtt_command, retries=self.command_retries)(topic, value)

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -177,8 +177,8 @@ class Am43Worker(BaseWorker):
 
         _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), device_name, data["mac"])
 
-        shade = Zemismart.Zemismart(
-            data["mac"], data["pin"], max_connect_time=self.per_device_timeout, withMutex=True)
+        shade = Zemismart.Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
+                                    withMutex=True, iface=data.get('iface'))
         try:
             with shade:
                 ret = []
@@ -244,7 +244,7 @@ class Am43Worker(BaseWorker):
         value = value.decode("utf-8")
         if field == "positionState" and action == "set":
             shade = Zemismart.Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
-                                        withMutex=True)
+                                        withMutex=True, iface=data.get('iface'))
             try:
                 with shade:
                     device_state = self.get_device_state(device_name, data, shade)
@@ -346,7 +346,7 @@ class Am43Worker(BaseWorker):
             self.last_target_position = target_position
 
             shade = Zemismart.Zemismart(data["mac"], data["pin"], max_connect_time=self.per_device_timeout,
-                                        withMutex=True)
+                                        withMutex=True, iface=data.get('iface'))
             try:
                 with shade:
                     # get the current state so we can work out direction for update messages

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -129,7 +129,9 @@ class Am43Worker(BaseWorker):
                 elif shade_position >= 100 - self.target_range_scale:
                     state = 'closed'
 
-                if time_from_last_update <= 10 and previous_position != 255:
+                if self.rapid_update_interval \
+                        and time_from_last_update <= self.rapid_update_interval * self.update_retries \
+                        and previous_position != 255:
                     if previous_position < shade_position:
                         state = 'closing'
                     elif previous_position > shade_position:

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -41,18 +41,19 @@ class Am43Worker(BaseWorker):
 
     def config_device(self, name, data, availability_topic):
         ret = []
+        device_class = data.get('hass_device_class', 'shade')
         device = {
             'identifiers': [data['mac'], self.format_discovery_id(data['mac'], name)],
             'manufacturer': 'A-OK',
             'model': 'AM43',
-            'name': self.format_discovery_name(name),
+            'name': '{} ({})'.format(device_class.title(), name),
         }
         ret.append(
             MqttConfigMessage(
                 MqttConfigMessage.COVER,
                 self.format_discovery_topic(data['mac'], name, 'shade'),
                 payload={
-                    'device_class': 'blind',
+                    'device_class': device_class,
                     'unique_id': self.format_discovery_id('am43', name, data['mac']),
                     'name': 'Blinds',
                     'availability_topic': "{}/{}".format(self.global_topic_prefix, availability_topic),

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -98,9 +98,12 @@ class Am43Worker(BaseWorker):
         battery = 0
         retry_attempts = 0
         while battery == 0 and retry_attempts < 5:
+            retry_attempts += 1
+
             # The docs for this library say that sometimes this needs called
             # multiple times, try up to 5 until we get a battery number
-            shade.update()
+            if not shade.update():
+                continue
 
             battery = shade.battery
 
@@ -248,7 +251,9 @@ class Am43Worker(BaseWorker):
                     device_position = self.correct_value(data, device_state["currentPosition"])
 
                     if value == 'STOP':
-                        shade.stop()
+                        if not shade.stop():
+                            raise AttributeError('shade.stop() failed')
+
                         device_state = {
                             "currentPosition": device_position,
                             "targetPosition": device_position,
@@ -272,7 +277,8 @@ class Am43Worker(BaseWorker):
 
                         # Yes, for open command we need to call close(), because "closed blinds" in AM43
                         # means that they're hidden, and the window is full open
-                        shade.close()
+                        if not shade.close():
+                            raise AttributeError('shade.close() failed')
                         device_state = {
                             "currentPosition": device_position,
                             "targetPosition": 0,
@@ -295,7 +301,8 @@ class Am43Worker(BaseWorker):
                         shade.stop()
 
                         # Same as above for 'OPEN': we need to call open() when want to close() the window
-                        shade.open()
+                        if not shade.open():
+                            raise AttributeError('shade.open() failed')
                         device_state = {
                             "currentPosition": device_position,
                             "targetPosition": 100,
@@ -363,7 +370,8 @@ class Am43Worker(BaseWorker):
                             state = "opening"
 
                         # send the new position
-                        shade.set_position(target_position)
+                        if not shade.set_position(target_position):
+                            raise AttributeError('shade.set_position() failed')
 
                         device_state = {
                             "currentPosition": device_position,

--- a/workers/am43.py
+++ b/workers/am43.py
@@ -9,8 +9,8 @@ from workers.base import BaseWorker
 _LOGGER = logger.get(__name__)
 
 REQUIREMENTS = [
-    "git+https://github.com/GylleTanken/python-zemismart-roller-shade.git"
-    "@36738c72d7382e78e1223c8ae569acab10f498e6#egg=Zemismart"
+    "git+https://github.com/andrey-yantsen/python-zemismart-roller-shade.git"
+    "@e919a3ae43d0c74b60e694815c3c3ce6ba83b0f4#egg=Zemismart"
 ]
 
 


### PR DESCRIPTION
# Description

In this PR, I continue to improve the AM43 worker: I made a few mistakes in the state detection logic in the last one, especially when blinds have moved since the previous update.

Also, in the previous PR, I added some magic to automatically reduce desired update interval to 3 seconds when some changes were detected — to handle the complete open/close procedure quickly: now I moved this hardcoded 3 seconds to a configuration variable, documenting both `default_update_interval` and the new `rapid_update_interval` on the way.

In addition, I've switched the worker to use a patched Zemismart driver, which helps to detect whether a command was successful.

Plus, now you can select a desired device class for the blinds in HASS (previously, it was hardcoded) :)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
