### PR TITLE
avoiding data errors (e.g. device out of reach/battery)

### DIFF
--- a/workers/lywsd03mmc_homeassistant.py
+++ b/workers/lywsd03mmc_homeassistant.py
@@ -124,6 +124,15 @@ class Lywsd03Mmc_HomeassistantWorker(BaseWorker):
                     type(e).__name__,
                     suppress=True,
                 )
+            except TypeError:
+                logger.log_exception(
+                    _LOGGER,
+                    "Data error during update of %s device '%s' (%s)",
+                    repr(self),
+                    name,
+                    device.mac,
+                    suppress=True,
+                )
             except DeviceTimeoutError:
                 logger.log_exception(
                     _LOGGER,


### PR DESCRIPTION
# Description

In some cases (e.g. device is completely out of battery), the whole execution will fail with a TypeError,  preventing live devices from updating as well.

Before the change, bt-mqtt-gateway would completely crash with this error:

```
bt-mqtt-gateway_1  | 14:46:36 Fatal error while executing worker command: TypeError
bt-mqtt-gateway_1  | Traceback (most recent call last):
bt-mqtt-gateway_1  |   File "./gateway.py", line 108, in <module>
bt-mqtt-gateway_1  |     raise e
bt-mqtt-gateway_1  |   File "./gateway.py", line 90, in <module>
bt-mqtt-gateway_1  |     mqtt.publish(_WORKERS_QUEUE.get(timeout=10).execute())
bt-mqtt-gateway_1  |   File "/application/workers_manager.py", line 45, in execute
bt-mqtt-gateway_1  |     for message in self._callback(*self._args):
bt-mqtt-gateway_1  |   File "/application/workers/lywsd03mmc_homeassistant.py", line 116, in status_update
bt-mqtt-gateway_1  |     yield self.update_device_state(name, device)
bt-mqtt-gateway_1  |   File "/application/workers/lywsd03mmc_homeassistant.py", line 162, in update_device_state
bt-mqtt-gateway_1  |     payload=self.true_false_to_ha_on_off(device.getBattery() < 3),
bt-mqtt-gateway_1  | TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

With this change, the error is logged, but execution can continue as usual.

Log would look like this

`14:48:36 Data error during update of lywsd03mmc_homeassistant device 'my_device' (a4:c1:38:**:**:**)`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
