### PR TITLE
miflora: Allow using different host adapter

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -69,6 +69,7 @@ manager:
     #   update_interval: 1800
     # miflora:
     #   args:
+    #     adapter: hci0
     #     devices:
     #       herbs: 00:11:22:33:44:55
     #     topic_prefix: miflora

--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -33,7 +33,8 @@ class MifloraWorker(BaseWorker):
             _LOGGER.debug("Adding %s device '%s' (%s)", repr(self), name, mac)
             self.devices[name] = {
                 "mac": mac,
-                "poller": MiFloraPoller(mac, BluepyBackend),
+                "poller": MiFloraPoller(
+                    mac, BluepyBackend, adapter=getattr(self, 'adapter', 'hci0')),
             }
 
     def config(self, availability_topic):


### PR DESCRIPTION
# Description

Currently MifloraWorker is hardcoded to the 'hci0' adapter.

Since hosts might have multiple adapters, allow selecting a
different one via the config.yaml.

Example:

    miflora:
      update_interval: 300
      args:
        adapter: hci3
        devices:
          myplant: AA:BB:CC:DD:EE:FF

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Signed-off-by: Philippe Mathieu-Daudé <f4bug@amsat.org>