### PR TITLE
Added retry to switchbot worker

### DIFF
--- a/workers/switchbot.py
+++ b/workers/switchbot.py
@@ -1,5 +1,3 @@
-import logging
-
 from mqtt import MqttMessage
 
 from workers.base import BaseWorker, retry
@@ -41,6 +39,7 @@ class SwitchbotWorker(BaseWorker):
         return ret
 
     def on_command(self, topic, value):
+        from bluepy.btle import BTLEException
 
         _, _, device_name, _ = topic.split("/")
 
@@ -91,7 +90,7 @@ class SwitchbotWorker(BaseWorker):
 
 def switch_state(bot, value):
     import binascii
-    from bluepy.btle import Peripheral, BTLEException
+    from bluepy.btle import Peripheral
 
     bot["bot"] = Peripheral(bot["mac"], "random")
     hand_service = bot["bot"].getServiceByUUID(SERVICE_UUID)

--- a/workers/switchbot.py
+++ b/workers/switchbot.py
@@ -1,9 +1,8 @@
-from builtins import staticmethod
 import logging
 
 from mqtt import MqttMessage
 
-from workers.base import BaseWorker
+from workers.base import BaseWorker, retry
 import logger
 
 REQUIREMENTS = ["bluepy"]
@@ -11,6 +10,14 @@ _LOGGER = logger.get(__name__)
 
 STATE_ON = "ON"
 STATE_OFF = "OFF"
+CODES = {
+    STATE_ON: "570101",
+    STATE_OFF: "570102",
+    "PRESS": "570100"
+}
+
+SERVICE_UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
+CHARACTERISTIC_UUID = "cba20002-224d-11e6-9fb8-0002a5d5c51b"
 
 
 class SwitchbotWorker(BaseWorker):
@@ -25,62 +32,46 @@ class SwitchbotWorker(BaseWorker):
         return "/".join([self.state_topic_prefix, *args])
 
     def status_update(self):
-        from bluepy import btle
 
         ret = []
         _LOGGER.debug("Updating %d %s devices", len(self.devices), repr(self))
         for name, bot in self.devices.items():
             _LOGGER.debug("Updating %s device '%s' (%s)", repr(self), name, bot["mac"])
-            try:
-                ret += self.update_device_state(name, bot["state"])
-            except btle.BTLEException as e:
-                logger.log_exception(
-                    _LOGGER,
-                    "Error during update of %s device '%s' (%s): %s",
-                    repr(self),
-                    name,
-                    bot["mac"],
-                    type(e).__name__,
-                    suppress=True,
-                )
+            ret += self.update_device_state(name, bot["state"])
         return ret
 
     def on_command(self, topic, value):
-        from bluepy import btle
-        import binascii
-        from bluepy.btle import Peripheral
 
         _, _, device_name, _ = topic.split("/")
 
         bot = self.devices[device_name]
 
+        switch_func = retry(switch_state, retries=self.command_retries)
+
         value = value.decode("utf-8")
 
-        # It needs to be on separate if because first if can change method
-
-        _LOGGER.debug(
+        _LOGGER.info(
             "Setting %s on %s device '%s' (%s)",
             value,
             repr(self),
             device_name,
             bot["mac"],
         )
-        try:
-            bot["bot"] = Peripheral(bot["mac"], "random")
-            hand_service = bot["bot"].getServiceByUUID(
-                "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
+
+        # If status doesn't change, the switchbot shouldn't move
+        if bot['state'] == value:
+            _LOGGER.debug(
+                "Ignoring %s on %s device '%s' with state %s",
+                value,
+                repr(self),
+                device_name,
+                bot["state"],
             )
-            hand = hand_service.getCharacteristics(
-                "cba20002-224d-11e6-9fb8-0002a5d5c51b"
-            )[0]
-            if value == STATE_ON:
-                hand.write(binascii.a2b_hex("570101"))
-            elif value == STATE_OFF:
-                hand.write(binascii.a2b_hex("570102"))
-            elif value == "PRESS":
-                hand.write(binascii.a2b_hex("570100"))
-            bot["bot"].disconnect()
-        except btle.BTLEException as e:
+            return []
+
+        try:
+            switch_func(bot, value)
+        except BTLEException as e:
             logger.log_exception(
                 _LOGGER,
                 "Error setting %s on %s device '%s' (%s): %s",
@@ -92,19 +83,19 @@ class SwitchbotWorker(BaseWorker):
             )
             return []
 
-        try:
-            return self.update_device_state(device_name, value)
-        except btle.BTLEException as e:
-            logger.log_exception(
-                _LOGGER,
-                "Error during update of %s device '%s' (%s): %s",
-                repr(self),
-                device_name,
-                bot["mac"],
-                type(e).__name__,
-                suppress=True,
-            )
-            return []
+        return self.update_device_state(device_name, value)
 
     def update_device_state(self, name, value):
         return [MqttMessage(topic=self.format_state_topic(name), payload=value)]
+
+
+def switch_state(bot, value):
+    import binascii
+    from bluepy.btle import Peripheral, BTLEException
+
+    bot["bot"] = Peripheral(bot["mac"], "random")
+    hand_service = bot["bot"].getServiceByUUID(SERVICE_UUID)
+    hand = hand_service.getCharacteristics(CHARACTERISTIC_UUID)[0]
+    hand.write(binascii.a2b_hex(CODES[value]))
+    bot["bot"].disconnect()
+    bot['state'] = STATE_ON if bot['state'] == STATE_OFF else STATE_OFF


### PR DESCRIPTION
# Description

When the switchbot fails to connect, the worker doesn't retry the action. With this change this is solved used the base worker retry function.

Also the worker has been modified to store the current state of the switch son now you can see the correct state in the MQTT status and now if the status has changed or not

Fixes #231 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
