### PR TITLE
Add `device_class` and `state_class` to EQ3 Valve Sensor

### DIFF
--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -176,7 +176,9 @@ class ThermostatWorker(BaseWorker):
             "name": self.format_discovery_name(name, SENSOR_VALVE),
             "state_topic": self.format_prefixed_topic(name, SENSOR_VALVE),
             "availability_topic": availability_topic,
+            "device_class": "power_factor",
             "unit_of_measurement": "%",
+            "state_class": "measurement",
             "device": device,
         }
         ret.append(


### PR DESCRIPTION
# Description

[Home Assistant](https://www.home-assistant.io/) picks up and autoconfigures perfectly the EQ3 thermostats exposed by this project.

A small issue is that the exposed valve sensor, as it is, is not recorded for long-term statistics as it lacks a couple of specifications. This makes it impossible for example to have a panel showing the heating usage per room throughout the day/week/month/year.

This PR adds `device_class` and `state_class` to the autodiscovery configuration for HA so that the correct icon is shown and statistics are possible.

I tested this works in my own HA instance by [building my own forked image](https://hub.docker.com/repository/docker/nonninz/bt-mqtt-gateway) and swapping it in `docker-compose.yaml`. The valves were immediately picked up with the correct type and recording statistics was then possible.

## Type of change

Somehow between new feature and bugfix? I'm not sure how to classify this.