### PR TITLE
Bump eq3bt and allow interface selection for thermostat

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -39,6 +39,7 @@ manager:
     #         mac: 00:11:22:33:44:55
     #         discovery_temperature_topic: some/sensor/with/temperature       # Optional current_temperature_topic for HASS discovery
     #         discovery_temperature_template: "{{ value_json.temperature }}"  # Optional current_temperature_template for HASS discovery
+    #         interface: 0                                                    # Optional interface id for bt communication
     #     topic_prefix: thermostat
     #   topic_subscription: thermostat/+/+/set
     #   update_interval: 60

--- a/workers/thermostat.py
+++ b/workers/thermostat.py
@@ -3,7 +3,7 @@ from mqtt import MqttMessage, MqttConfigMessage
 from workers.base import BaseWorker, retry
 import logger
 
-REQUIREMENTS = ["python-eq3bt==0.1.11"]
+REQUIREMENTS = ["python-eq3bt==0.1.12"]
 _LOGGER = logger.get(__name__)
 
 MODE_HEAT = "heat"
@@ -44,7 +44,7 @@ class ThermostatWorker(BaseWorker):
             elif isinstance(obj, dict):
                 self.devices[name] = {
                     "mac": obj["mac"],
-                    "thermostat": Thermostat(obj["mac"]),
+                    "thermostat": Thermostat(obj["mac"], obj.get("interface")),
                     "discovery_temperature_topic": obj.get(
                         "discovery_temperature_topic"
                     ),


### PR DESCRIPTION
# Description

Bluetooth interface selection for thermostat communication was added to python-eq3bt in version 0.1.12. This change allows choosing the Bluetooth interface via the configuration file.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
