### PR TITLE
revert specific commit miflora version dependency

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -7,11 +7,8 @@ from workers.base import BaseWorker, retry
 import logger
 
 REQUIREMENTS = [
-    # Reference specific commit to include the transitive dependency
-    # btlewrap in version 0.0.9. This should be reverted to just
-    # "miflora" once miflora version > 0.6 is available on pypi.
-    "git+https://github.com/open-homeautomation/miflora.git@ebda66d1f4ba71bc0b98f8383280e59302b40fc8#egg=miflora",
-    "bluepy"
+    "bluepy",
+    "miflora",
 ]
 
 ATTR_BATTERY = "battery"


### PR DESCRIPTION
# Description

miflora > 0.6 is available on pypi, so we can revert the dependency on a specific (old) commit of the miflora library.

This is actually just following a comment in the code which mentions that this can be done. The newer version seems to work fine here.
