### PR TITLE
Limit light level readings from MiFlora sensors

### DIFF
--- a/workers/miflora.py
+++ b/workers/miflora.py
@@ -134,10 +134,23 @@ class MifloraWorker(BaseWorker):
         ret = []
         poller.clear_cache()
         for attr in monitoredAttrs:
+            payload = poller.parameter_value(attr)
+
+            # We sometimes see light values of over 400 million. This
+            # probably comes from a sensor error or maybe the miflora
+            # library not understanding the protocol completely.
+            #
+            # In any case, direct sunlight is up to 100 thousand lux,
+            # so anything above that is suspicious. Lets cap our value
+            # at 1 million lux, an order of magnitude more than we ever
+            # expect.
+            if (attr == "light") and (payload > 1_000_000):
+                continue
+
             ret.append(
                 MqttMessage(
                     topic=self.format_topic(name, attr),
-                    payload=poller.parameter_value(attr),
+                    payload=payload,
                 )
             )
 


### PR DESCRIPTION
# Description

I noticed that periodically one of my MiFlora-monitored plants would report a [DLI](https://en.wikipedia.org/wiki/Daily_light_integral) way too high, which is impossible for my plants. This turned out to be because they were getting a single illumination value that was incredibly high. I tracked it down, and it seems to be something like 400 million, which is suspiciously like 2^32 / 10, which is the maximum value from the sensor (there is a division by 10.0 in the code).

It _might_ be that an all-1 reading has some meaning within the protocol that the library does not account for. Or it might be that the sensors have some bug that sometimes returns that value. I am not sure.

The solution in this PR is a hack, which basically just throws out any illumination value that is unrealistically high. I chose 10 times the maximum daylight value, as listed on the Wikipedia:

https://en.wikipedia.org/wiki/Lux

It should have no impact on properly-functioning sensors returning reasonable values.

So far it has prevented any additional weird values, although it has not yet been running two days.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
